### PR TITLE
add meeting notes to vsc branch

### DIFF
--- a/meeting-notes/2022/2022-05-23_kickoff.md
+++ b/meeting-notes/2022/2022-05-23_kickoff.md
@@ -1,0 +1,130 @@
+# VSC Central Software Installation
+
+## Notes kickoff meeting 2022-05-23
+
+### Attendees (+ experience with EasyBuild)
+
+- UGent
+    - Kenneth Hoste: EasyBuild lead developer
+    - Balazs Hajgato: quite experienced, but now a bit rusty, mostly easyconfigs + tweaking easyblocks
+    - Stijn De Weirdt: original creator, no experience anymore, interested in workflow + organisation
+    - Ewald Pauwels: no hands-on experience, interested in workflow + organisation
+- VUB
+    - Samuel Moors: EasyBuild maintainer, easyconfigs + easyblocks
+    - Alex Domingo: EasyBuild maintainer, easyconfigs + easyblocks
+- KUL
+    - Mag Selwa: using EasyBuild, mostly easyconfigs
+    - Alexander Vapirev: easyconfigs + modifying easyblocks
+    - Ehsan Moravveji: experience with using easyconfigs, easyblocks as inspiration as for manual installs
+    - Maxime Van Den Bossche: modifying easyconfigs
+    - (excused) Steven Vandenbrande: ???
+    - Jan Ooghe: no experience, interested in workflow + organisation
+- UH:
+    - Geert Jan Bex: easyconfigs/easyblocks, but rusty currently
+- UA
+    - Franky Backeljauw: some experience with easyconfigs, little bit with easyblocks
+    - Engelbert Tijskens: no experience at all on EasyBuild
+    - Robin Verschoren: some experience modifying easyconfigs, less with easyblocks (but can tweak if needed)
+    - Stefan Becuwe: similar as Robin
+
+### Scope & goals
+
+- work together (more) on central software installations
+- *using* (not developing) EasyBuild: composing easyconfigs, leveraging existing generic easyblocks
+- avoid duplicate work
+- share expertise, help each other where it makes sense
+- non-goals:
+    - let others do the work for you
+    - site-specific customizations that are deemed necessary by a particular site
+
+### Current approach at HPC-UGent
+
+- all software installation requests (Tier-2 + Tier-1 Hortense) come in via form @ https://www.ugent.be/hpc/en/support/software-installation-request
+    - no exceptions: if email is sent to hpc@ugent.be, we reply with "please use form"
+    - OTRS ticket with all submitted info is created in software requests queue, which is used for communication with user
+    - auto-reply that install request was created
+    - room for improvement
+        - integration with VSC accountpage (to automatically get requester info, like email + VSC account)
+        - no easy way to see if software is already supported in EasyBuild
+- triage is done by Kenneth + Balazs
+    - usually an issue is opened in (private) `eb_inuits` repository for each install request
+    - easy version update: may do it ourselves (unless it turns out to be more difficult than anticipated)
+    - issues are labeled with priority, expected difficulty
+    - some initial guidance info is included in issue: toolchain, easyblock, attention points
+    - INUITS consultants pick up on issues
+    - weekly call (~1h) with consultants to discuss where they got stuck
+    - PRs are opened to central easyconfigs repo, reviewed + merged by Kenneth/Balazs or other EasyBuild maintainer
+- central software installation at HPC-UGent
+    - using EasyBuild develop branch, updated manually at regular intervals
+    - often also installing from open PR (`eb --from-pr`)
+    - **this is not ideal** (not keeping track of what's in central software stack + how it was installed)
+    - we are looking into ways of improving this: easystack file(s) to keep track of what's installed + automate "deployment" via bot (GitHub app)
+- site customizations for HPC-UGent
+    - in some places we diverge from what EasyBuild does by default
+    - implemented in EasyBuild hooks + using custom easyconfigs that are injected with priority
+    - private `hpcugent/software-stack` repo (GitHub UGent)
+
+### Practical
+
+- 2 people max per site, to have focused effort
+    - they spent a significant amount of their time on central software installations with EasyBuild
+    - UGent: Kenneth + Balazs
+    - VUB: Sam + Alex
+    - KUL:
+    - UA:
+- central form for software installation requests
+    - triggers support ticket in UGent OTRS queue (site-specific)
+    - communication with researcher who requested the installation
+    - end goal is to reply with "software is installed, use '`module load XXX`' "
+- central (private) GitHub repository (https://github.com/vscentrum/vsc-software-stack)
+    - GitHub issue per software installation request to discuss problems (internally), etc.
+    - EasyBuild "experts" (Kenneth, Sam, Alex) can do triage (OTRS -> GitHub issue) + give guided info in issue on which easyblock to use, likely attention points, etc.
+    - repo serves as sandbox where work-in-progress easyconfigs can be stored (separate subdir per issue)
+    - just push to `main` branch (no PRs)
+    - mainly to easily share draft easyconfigs and work together/get help
+    - very similar to `eb_inuits` private repository already used by HPC-UGent + INUITS consultants, which is working quite well
+    - intention is to open pull request to central easyconfigs repository once easyconfig(s) are working
+- weekly (or bi-weekly) meetings to discuss work-in-progress
+    - short stand-up meetings: only raise issues, don't try to fix them
+    - hard cap to 30m (weekly) or 1h (bi-weekly) in total
+- direct way of communicating, for example via EasyBuild (or VSC) Slack
+
+### EasyBuild training session
+
+- strong focus on aspects of EasyBuild relevant to this working group
+- not a full EasyBuild tutorial!
+- in scope:
+    - writing easyconfigs
+    - leveraging generic easyblocks
+    - GitHub integration (`eb --new-pr` & co)
+    - implementing hooks to do site customisations efficiently
+- out of scope:
+    - implementing easyblocks
+    - implementing additional features in EasyBuild framework
+    - EasyBuild features not relevant to this working group
+
+### Links
+
+- https://easybuild.io/tutorial/
+- https://easybuilders.github.io/easybuild-tutorial/2021-lust/implementing_easyblocks/
+
+### Q&A
+
+- mostly easyconfigs-only, not easyblocks
+- acceptance policy for easyconfigs
+    - works on local VSC site + EasyBuild test bot
+        - see for example https://github.com/easybuilders/easybuild-easyconfigs/pull/15443
+- build_tools bundle to central easyconfigs
+    - M4, Bison, flex, Autotools, make, Ninja, Meson, SCons, ...
+- force us of software install request form?
+    - right now it's too Ghent specific
+    - feedback wanted from others before making it a requirements for people outside of UGent
+
+### Actions items
+
+- set up repo
+- plan training
+- UA/KUL: pick names
+- plan follow-up meeting (end of June/early July)
+- create OTRS subqueues
+- update install request form to also mention other VSC sites

--- a/meeting-notes/2022/2022-07-12.md
+++ b/meeting-notes/2022/2022-07-12.md
@@ -1,0 +1,3 @@
+## Sync meeting 2022-07-12
+
+- (no notes taken?)

--- a/meeting-notes/2022/2022-07-26.md
+++ b/meeting-notes/2022/2022-07-26.md
@@ -1,0 +1,3 @@
+## Sync meeting 2022-07-26
+
+- (no notes taken?)

--- a/meeting-notes/2022/2022-08-09.md
+++ b/meeting-notes/2022/2022-08-09.md
@@ -1,0 +1,17 @@
+## Sync meeting 2022-08-09 (13:30 CEST)
+
+- joining: Kenneth, Mag, Maxime, Alexander
+- excused: Alex
+
+### Agenda/notes
+
+- feedback on EasyBuild training session (2022-06-29)
+    - slides available at https://docs.google.com/presentation/d/1pz8d9_0CFirhf-td7XhC6MPFGqw6t-zKnIZSFXirmDo
+    - recording was shared with Mag, Geert-Jan, Robin via Belnet FileSender
+- issues for software installation requests @ https://github.com/vscentrum/vsc-software-stack/issues
+    - anything in particular to discuss?
+- any objections to making vsc-software-stack repository public?
+    - by request of HPC-UGent consultants
+    - helpful in case external help is available (for example via EasyBuild community, developers of the software, etc.)
+- update on problems with older Intel MPI versions on RHEL 8.6
+    - see https://github.com/easybuilders/easybuild-easyconfigs/issues/15651

--- a/meeting-notes/2022/2022-08-23.md
+++ b/meeting-notes/2022/2022-08-23.md
@@ -1,0 +1,33 @@
+## Sync meeting 2022-08-23 (13:30 CEST)
+
+- joining: Kenneth, Sam, Robin, Balazs, Alexander
+- excused: Mag, Maxime
+
+### Agenda
+
+- feedback on EasyBuild training session (2022-06-29)
+    - slides available at https://docs.google.com/presentation/d/1pz8d9_0CFirhf-td7XhC6MPFGqw6t-zKnIZSFXirmDo
+    - recording was shared with Mag, Geert-Jan, Robin via Belnet FileSender
+
+- issues for software installation requests @ https://github.com/vscentrum/vsc-software-stack/issues
+    - anything in particular to discuss?
+    - anyone familiar with openLISEM (https://github.com/vscentrum/vsc-software-stack/issues/25)?
+
+- any objections to making vsc-software-stack repository public?
+    - by request of HPC-UGent consultants
+    - helpful in case external help is available (for example via EasyBuild community, developers of the software, etc.)
+    - no objections from Sam/Robin
+
+- update on problems with older Intel MPI versions on RHEL 8.6
+    - see https://github.com/easybuilders/easybuild-easyconfigs/issues/15651
+    - kernel patch available to fix userland breakage: https://github.com/torvalds/linux/commit/7ee951acd31a88f941fd6535fbdee3a1567f1d63
+
+- Robin: how to avoid that EasyBuild uses -xHost on AMD systems
+    - optarch flag that is used can be controlled (per compiler), see https://docs.easybuild.io/en/latest/Controlling_compiler_optimization_flags.html#setting-architecture-flags-for-different-compilers-via-optarch-compiler-flags-compiler-flags
+    - for example `export EASYBUILD_OPTARCH="Intel:march=core-avx2"`
+    - WIP PR to make EasyBuild do the right thing: https://github.com/easybuilders/easybuild-framework/pull/3797
+
+- experiences with installing TELEMAC (on BrENIAC)?
+    - see https://hydro-informatics.com/get-started/install-telemac.html
+    - is available on KUL Tier-2 (manually installed, not with EasyBuild)
+    - will probably need to be provided on Hortense as well (we expect to get an installation request soon)

--- a/meeting-notes/2022/2022-09-06.md
+++ b/meeting-notes/2022/2022-09-06.md
@@ -1,0 +1,38 @@
+## Sync meeting 2022-09-06 (13:30 CEST)
+
+- attending: Kenneth, Balazs, Sam, Robin, Steven, Mag, Alexander, Maxime
+- not attending: Alex, Ehsan, Bert
+
+### Agenda
+
+- Any need for an EasyBuild training session beyond the basics?
+    - Possible topics:
+        - hooks
+        - more specific:
+            - installing (a set of) Python packages (best practices) as stand-alone, extension, bundle, ...
+            - mix of things: C++, Python/R bindings, ...
+        - more ideas
+- Update on Intel MPI trouble with RHEL 8.6
+    - kernel patch is expected to land in a RHEL 8 kernel soon
+    - see https://github.com/easybuilders/easybuild-easyconfigs/issues/15651
+- Any objections to making https://github.com/vscentrum/vsc-software-stack a public repo?
+    - Will need to be careful w.r.t. licensed software like Gaussian & VASP
+- No installation request received for TELEMAC on Hortense
+    - Handled by users themselves?
+    - They did open a request for openLISEM
+- Quick demo of EESSI on HPC-UGent systems
+    - https://eessi.github.io/docs
+        - accessing EESSI via a container (no admin rights needed): https://eessi.github.io/docs/pilot/#accessing-the-eessi-pilot-repository-through-singularity
+    - paper: https://doi.org/10.1002/spe.3075
+    - demo scripts for GROMACS, OpenFOAM, ...: https://github.com/EESSI/eessi-demo
+    - Should we set up our own VSC CVMFS repository to work together on a central software stack for all VSC systems?
+    - EESSI should also be available in VUB Hydra as well
+    - to get started:
+        - ls /cvmfs/pilot.eessi-hpc.org
+        - source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash
+- Software stack on new KUL RHEL8 system
+    - Currently software is only installed on demand
+    - Only recent toolchains: currently only 2021a toolchains
+- For UGent migration to RHEL8
+    - As much modules as possible (with moderate effort) were installed
+    - Oldest toolchains are foss/2019b + intel/2019b (with some necessary tweaks)

--- a/meeting-notes/2022/2022-09-20.md
+++ b/meeting-notes/2022/2022-09-20.md
@@ -1,0 +1,23 @@
+## Sync meeting 2022-09-20 (13:30 CEST)
+
+- attending: Kenneth, Alex, Maxime, Alexander, Robin, Mag
+- not attending: Sam, Balazs, Bert, Steven, Ehsan
+
+### Agenda
+
+- more in depth training session on EasyBuild (hooks, installing Python packages, ...)?
+    - framework deep dive => better suited for an open EB call/session
+    - some date in Oct'22? => KH will set up a doodle
+- feedback on EESSI? need for a dedicated session on EESSI?
+    - see introductory talks at EESSI meeting last week https://eessi.github.io/docs/meetings/2022-09-amsterdam
+    - just make EESSI available at all VSC sites vs building our own EESSI-like shared software stack from scratch
+    - may depend on how easy it is to tweak module files provided by EESSI
+    - Robin: any performance impact?
+        - GROMACS performance scaling: see EESSI paper (https://doi.org/10.1002/spe.3075, section 6)
+            - on-par performance for GROMACS with 16,000 cores with system installation on JUSUF @ JSC
+        - TODO:
+            - evaluate impact on startup performance for large MPI workloads
+            - broader study of performance for various scientific applications
+- https://github.com/vscentrum/vsc-software-stack/issues
+    - TELEMAC & openLISEM are being installed on Hortense, quite a bit of effort to get these supported in EasyBuild...
+- other topics?

--- a/meeting-notes/2022/2022-10-04.md
+++ b/meeting-notes/2022/2022-10-04.md
@@ -1,0 +1,28 @@
+## Sync meeting 2022-10-04 (13:30 CEST)
+
+- attending: Kenneth, Alex, Sam, Robin, Maxime, Balazs
+- not attending: Mag, Alexander, Bert? Steven? Ehsan?
+
+### Agenda
+
+- YALES2
+    - see https://github.com/vscentrum/vsc-software-stack/issues/32
+    - PR @ https://github.com/easybuilders/easybuild-easyconfigs/pull/16345
+    - EasyBuild should have support for expanding environment variables at module load time
+        - for example:
+            - modextravars = {'Y2_PYTHON_EXEC': "foo/${EBROOTPYTHON}/bin/python3"}
+            - with support for disabling expanding via "expand_env_vars = False" or using $$
+            - + warning when $ is used without curly braces
+- AMS
+    - see https://github.com/vscentrum/vsc-software-stack/issues/35
+    - SM is working on a PR for the easyconfig that is used 
+- new Tier-2 cluster @ KUL
+    - Intel Icelake + A100 + bigmem partition
+    - BH: How's the memory bandwidth?
+        - AMD Rome/Milan is very sensitive to core pinning (cfr. OpenFOAM)
+    - @ HPC-UGent: setting $OMP_PROC_BIND=1 by default since a couple of months (on Tier-2 clusters + Tier-1 Hortense)
+        - but needs to be disabled for some software, like FLUENT, R, PyTorch, ...
+            - for R, $OMP_PROC_BIND should NOT be set otherwise it pins itself to a single core at startup, which destroys performance of R libraries using doParallel...
+        - required for a specific Linux kernel + because we use non-standard NUMA layout on our AMD systems
+        - mympirun also does some magic, especially when "mympirun --hybrid" is used
+        - significant differences w.r.t. (default) core pinning between Intel MPI & Open MPI

--- a/meeting-notes/2022/2022-10-18.md
+++ b/meeting-notes/2022/2022-10-18.md
@@ -1,0 +1,34 @@
+## Sync meeting 2022-10-18 (13:30 CEST)
+
+- attending: Kenneth, Sam, Alex, Robin, Maxime, Balazs
+- not attending: Mag, Alexander, Bert, Steven, Ehsan
+
+### Agenda
+
+- recent issues in https://github.com/vscentrum/vsc-software-stack/issues
+    - sources for cdbtools (https://github.com/vscentrum/vsc-software-stack/issues/44)
+- new EasyBuild release soon (this week?)
+    - patches for GCC + OpenBLAS to fix failing LAPACK tests (which affect VASP)
+        - see https://github.com/easybuilders/easybuild-easyconfigs/issues/16380
+        - patch for GCC 11.x + 12.x to fix vectorizer bug: https://github.com/easybuilders/easybuild-easyconfigs/pull/16411
+            - also reported upstream, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107254
+        - so applies to `foss/2021b` + `foss/2022a`
+        - OpenBLAS patches (+ enabling running of LAPACK tests): https://github.com/easybuilders/easybuild-easyconfigs/pull/16406
+        - in theory, everything build with GCC (and `-ftree-vectorize`) or statically linked to OpenBLAS should be rebuilt
+        - "safe" in-place updates of GCC + OpenBLAS could be built via bwrap, something like:
+          ```
+          bwrap --bind / / --bind /tmp/apps/gent /apps/gent --dev /dev --bind /dev/log /dev/log eb GCCcore-11.3.0.eb -f
+          mv /tmp/apps/gent/software/GCCcore/11.3.0 /apps/gent/software/GCCcore/
+          # or 'cp', but that's less "atomic"
+          ```
+    - SYSTEM instead of True in dependency specification
+        - https://github.com/easybuilders/easybuild-easyconfigs/pull/16384
+    - correctly count number of failing PyTorch tests
+        - https://github.com/easybuilders/easybuild-easyblocks/pull/2794
+- Alex has a work-in-progress easyblock for installing Julia packages
+- Maxime: EasyBuild approach to deprecation of classic Intel compiler
+    - icc + icpc classic compilers will no longer be supported end of 2023 (?)
+    - support for 'oneapi' toolchain option was added in EasyBuild, see https://github.com/easybuilders/easybuild-framework/pull/4031/
+    - from some Intel version onwards, 'oneapi' toolchain option will be enabled by default
+        - opt-out will be possible via toolchainopts = {'oneapi': False}
+- RHEL8 Intel MPI issue is fixed, see https://github.com/easybuilders/easybuild-easyconfigs/issues/15651

--- a/meeting-notes/2022/2022-11-15.md
+++ b/meeting-notes/2022/2022-11-15.md
@@ -1,0 +1,60 @@
+## Sync meeting 2022-11-15 (13:30 CET)
+
+- attending: Sam, Maxime, Mag, Robin, Steven, Alex, Balazs
+- not attending: 
+
+### Agenda
+
+- OK to stick to monthly meetings?
+    - no objections
+- IJulia (https://github.com/vscentrum/vsc-software-stack/issues/45)
+    - new JuliaPackage generic easyblock merged
+    - IJulia easyconfig also merged
+    - Alex: unclear what the impact of install Julia itself with a non-system toolchain will be on 'jll' Julia packages which are wrappers around pre-built libraries
+        - for example https://github.com/JuliaBinaryWrappers/ZeroMQ_jll.jl
+    - users can still overrule centrally installed Julia package via $JULIA_DEPOT_PATH
+- COOLFluiD (https://otrsdict.ugent.be/otrs/index.pl?Action=AgentTicketZoom;TicketID=88366)
+    - ideally Steven gives on overview of the work he has done here
+    - initial (user) installation on top of foss/2020a was problematic
+        - produced wrong results, and eventually crashed hard (with segfaults)
+        - problems disappeared when using foss/2021a
+            - we should check if similar problems occur on Genius with foss/2020a
+        - over 2x speedup on Genius when using foss/2021a instead of foss/2018a
+- 2022b update of common toolchains
+    - candidates available
+        - https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/i/intel/intel-2022.09.eb
+        - https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/f/foss/foss-2022.10.eb
+    - overview:
+        - foss/2022.10
+            - GCC 12.2.0 + binutils 2.39 (latest)
+                - GCC 12 automatically enables -free-vectorize
+            - UCX 1.13.1 + libfabric 1.16.1 + OpenMPI v4.1.4 (latest) - same as in foss/2022a
+            - FlexiBLAS 3.2.1 w/ OpenBLAS 0.3.21 as default backend + BLIS 0.9.0  (latest)
+            - FFTW 3.3.10 (latest) - same as in foss/2022a
+            - ScaLAPACK 2.2.0 (latest)
+        - intel/2022.09
+            - base: GCC 12.2.0 + binutils 2.39
+            - Intel C/C++/Fortran compilers 2022.2.0 (classic + oneAPI)
+                - should be updated to 2022.2.1 (released 2 Nov'22)
+            - Intel MPI 2021.7.0 (latest)
+                - should be updated to 2021.7.1 (released 2 Nov'22)
+            - Intel MKL 2022.2.0 (latest)
+                - should be updated to 2022.2.1 (released 2 Nov'22)
+            - intention is to use C/C++ oneAPI compilers by default
+                - opt-out using 'one_api_c_cxx': 'False' in toolchainopts
+                - to be implemented, currently only 'oneapi' toolchain option supported (disabled by default)
+    - 2022b common toolchains will be included with next EasyBuild release (v4.7.0)
+- Balazs: OpenFOAM 7 with foss/2019b sometimes crashed with `btl_openib_component.c:3644:handle_wc REMOTE ACCESS ERROR`
+    - should be able to avoid this using a newer toolchain version (which includes UCX)
+    - building OpenFOAM 7 with a more recent toolchain is not a smooth ride though...
+    - https://otrsdict.ugent.be/otrs/index.pl?Action=AgentTicketZoom;TicketID=100613
+- easyconfigs using an ancient toolchains (GCC < 8.0 and foss/intel < 2019a) will be archived, see also https://docs.easybuild.io/en/latest/Deprecated-easyconfigs.html#deprecated-toolchains
+- segfault in FlexiBLAS (https://github.com/easybuilders/easybuild-easyconfigs/issues/16387)
+    - fixes with patch in OpenBLAS to work around it: https://github.com/easybuilders/easybuild-easyconfigs/pull/16510
+        - may have some performance impact, but should be minimal (and is better than crashes)
+        - only affects BLAS level 1 routines
+    - see also compiler bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107451
+- Sam: using bwrap wrapper for EasyBuild to be able to do "in place" updates for software that needs to be rebuilt
+    - see for example recent fixes for GCCcore + OpenBLAS
+    - see https://github.com/easybuilders/easybuild-framework/issues/4110
+    - upstream: https://github.com/containers/bubblewrap

--- a/meeting-notes/2022/2022-12-13.md
+++ b/meeting-notes/2022/2022-12-13.md
@@ -1,0 +1,9 @@
+## Sync meeting 2022-12-13 (13:30 CET)
+
+- attending: Engelbert, Robin, Maxime, Sam
+- not attending: Kenneth, Alex, Balazs
+
+### Agenda
+
+- Problems running Orca multinode in Antwerpen
+    - job submitted in Hydra today (vsc20133)

--- a/meeting-notes/2023/2023-01-10.md
+++ b/meeting-notes/2023/2023-01-10.md
@@ -1,0 +1,48 @@
+## Sync meeting 2023-01-10 (13:30 CET)
+
+- attending: Kenneth, Sam, Maxime, Robin, Mag, Alex, Balazs
+- not attending: Balazs
+
+### Agenda
+
+- significant increase in software installation requests @ UGent
+    - overal ticket count: 2019: 1,298 - 2020: 1,552 - 2021: 1,904 - 2022: 2,620
+    - 2020: 258 - 2021: 241 - **2022: 376**
+    - currently a backlog of ~180 open tickets @ HPC-UGent (Tier-2 + Tier-1)
+    - a student intern with basic Linux/Python knowledge was able to resolve ~50% of tickets over summer
+        - without having admin access or being able to log into VSC accounts
+        - we expect ~+20% if he would have had admin access
+    - only partially explained by Hortense, there's more going on...
+        - are you also seeing an increase in "easy" tickets?
+        - @KUL: large part of tickets can be answered by pointing out to the documentation
+    - are other sites seeing this trend too?
+    - @KUL: upward trend as well in number of tickets, not clear how steep
+    - @VUB: increasing number of tickets, but software install requests are stable over last couple of years
+        - 2022: 50% more than in 2021 (but partially due to DC move)
+        - some software is installed proactively (PyTorch, TensorFlow, ...)
+        - ~90% of requests requires creating a new easyconfig (often just a version bump)
+    - would installing everything that EasyBuild supports be a significant help?
+    - a way to users request something to be installed that's already installed in EasyBuild
+        - could be helpful to get installs in place quickly, can be automated
+- EuroHPC project MultiXscale started on 1 Jan 2023
+    - one of the goals is to make EESSI stable and ready for production use
+    - we hope/expect to make a lot of progress in the next couple of months
+    - build-and-deploy bot being developed (https://github.com/EESSI/eessi-bot-software-layer) is an important task
+- EasyBuild v4.7.0 released
+    - https://docs.easybuild.io/en/latest/Release_notes.html
+    - highlights: https://github.com/easybuilders/easybuild/releases/tag/easybuild-v4.7.0
+    - running EasyBuild on top of Python 2 is deprecated!
+    - includes foss/2022b + intel/2022b toolchain definitions
+    - use of Intel oneAPI C/C++ compilers is auto-enabled by default
+- trouble with latest scipy: update to easyblock needed
+    - due to switch from distutils-based installation to Meson
+    - see https://github.com/easybuilders/easybuild-easyblocks/pull/2848
+- EasyBuild docs being ported to MarkDown
+    - preview available at https://easybuilders.github.io/easybuild-docs
+- problem with GPU not being found when EasyBuild is running test for NAMD
+    - turns out this was due not not binding `/dev/nvidia*` with bwrap
+- Block easyconfig (dependency for PySCF - see https://github.com/vscentrum/vsc-software-stack/issues/37)
+    - correct version is at https://github.com/sanshar/StackBlock (not https://github.com/sanshar/Block, which is an old version)
+    - requires (deprecated) C++ bindings of OpenMPI...
+    - can be installed without MPI support (only OpenMP), may be good enough for PySCF
+- PR for QIIME2 with foss/2022a was stuck due to numba PR

--- a/meeting-notes/2023/2023-02-14.md
+++ b/meeting-notes/2023/2023-02-14.md
@@ -1,0 +1,44 @@
+## Sync meeting 2023-02-14 (13:30 CET)
+
+- attending: Sam, Alex, Balazs, Franky, Robin, Maxime, Kenneth
+- not attending: Mag
+
+### Agenda
+
+- (Alex) Proposal to create a single VSC repo for easyconfigs
+  - motive: whenever there is a new software request it is complicated to know if that easyconfig already exists or if somebody is working on it. Now we have to
+    - (VSC fork)
+    - navigate upstream repo
+    - search open PRs
+    - search issues in vsc-software-stack
+    - ask Sam politely
+  - pushing everything upstream is undoable for multiple reasons:
+    - version divergence with upstream repo
+    - merging of PRs can stall for long time
+    - custom hacks that are too ugly for upstream standards
+  - we could simplify our workflow by having a single VSC repo for easyconfigs
+    - fork of upstream + all easyconfigs of software installed in VSC clusters
+    - ideally nothing should be installed in a cluster if it does not have its easyconfig in this VSC repo
+  - current approach at UA
+      - fork of upstream easyconfigs repo + separate repo with own easyconfigs (https://github.com/hpcuantwerpen/UAntwerpen-easyconfigs)
+  - current approach at KUL
+      - no central repo with custom easyconfigs used by KUL
+      - contributing back easyconfigs is done via personal forks
+  - current approach at UGent
+      - private repo with custom easyconfigs/toolchains/hooks (not a full fork)
+          - cluster-specific (e.g. AMD CPUs), OS-specific, generic easyconfigs, which get preference over what's included with EasyBuild
+      - contributions to upstream are done via personal forks (after testing in personal VSC account)
+      - production installations are done using EasyBuild develop branch
+      - sometimes using "eb --from-pr ..." (not waiting until PR is merged upstream)
+  - current approach at VUB
+      - using EasyBuild develop
+      - using personal forks to contribute easyconfigs upstream
+      - rarely installing from open easyconfig PRs
+  - VSC fork could also be a place to share EasyBuild hooks
+- UAntwerpen is looking to re-work and update the toolchain, with a possible jump to 2022*b*. Hoping for some advice from other hubs:
+    - Expectedly, there can be some applications that are present in 2022a, but missing in 2022b. How should we go about updating those (e.g. version numbers of dependencies/packages)?
+        - mostly due to SciPy-bundle https://github.com/easybuilders/easybuild-easyconfigs/pull/16912, blocked by https://github.com/easybuilders/easybuild-easyblocks/pull/2862
+    - What is preferred to install e.g. extra Python/R/... packages: a separate EasyConfig with a bundle, extensions, ...?
+    - What is the software install policy in other hubs: install only after user request, or are some packages installed sooner?
+        - at UGent: toolchains, Perl, Python + SciPy-bundle, R + Bioconductor, OpenFOAM (+ all required dependencies)
+    - Are there any (central) plans for more documentation in the EasyConfigs?

--- a/meeting-notes/2023/2023-03-16.md
+++ b/meeting-notes/2023/2023-03-16.md
@@ -1,0 +1,31 @@
+## Sync meeting 2023-03-16 (09:00 CET)
+
+- attending: Alex, Balazs, Steven, Maxime, Mag, Robin
+- no attending: Sam
+
+### Agenda
+
+- (Alex) VSC fork of easyconfigs setup
+    - based on Git worktrees, allow to check out branches like (sub)directories
+    - advantage over just a bunch of subdirectories is that branches can have different rules attached to them to enforce review/testing policies
+    - proof-of-concept setup, see https://github.com/lexming/vsc-software-stack
+    - next steps:
+        - set up 'wip', 'vsc', 'site-*' branches in https://github.com/vscentrum/vsc-software-stack
+        - switch to 'wip' branch, remove 'main' branch
+        - extend docs in README (use cases section)
+- (Alex) FunGAP almost done (https://github.com/vscentrum/vsc-software-stack/issues/95)
+    - record of most dependencies? (178)
+- LISEM (https://github.com/vscentrum/vsc-software-stack/issues/25)
+    - WIP by Sam
+    - dependencies are in place, but running into Windows-specific C++ code...
+    - see also discussion on running LISEM on Linux: https://github.com/bastianvandenbout/LISEM/discussions/12
+- SuiteSparse with intel toolchain requires *a lot* of memory to compile
+    - see https://github.com/easybuilders/easybuild-easyconfigs/pull/17285
+    - (Steven) at KUL, ~120GB of memory was used during the installation
+    - (Balazs) could try to use `-O1` instead of `-O2`
+        - `toolchainopts = {'lowopt': True}` => -O1 for everything
+        - or add patch to only compile memory-intensive file to only compile that file with -O1
+- Ilastik (https://github.com/vscentrum/vsc-software-stack/issues/62)
+    - requires lots of dependencies, incl. TensorFlow 1.14
+    - unclear whether it's worth the effort to install it from source
+    - should check with Stijn for who this is needed (or why)

--- a/meeting-notes/2023/2023-04-13.md
+++ b/meeting-notes/2023/2023-04-13.md
@@ -1,0 +1,26 @@
+## Sync meeting 2023-04-13 (09:20 CEST)
+
+- attending: Kenneth, Steven
+- no attending:
+
+### Agenda
+
+- feedback on vsc/site-*/wip branches setup in vsc-software-stack
+    - `wip` branch is created, and already being used by some
+    - `main` branch is also still used, needs to be collapsed into `wip` and removed
+    - `vsc` branch should be made default branch
+    - PR that updates README should be re-reviewed and merged: https://github.com/vscentrum/vsc-software-stack/pull/111
+- AlphaFold 2.3.1
+    - see https://github.com/vscentrum/vsc-software-stack/issues/118 + https://github.com/vscentrum/vsc-software-stack/tree/main/118_AlphaFold
+    - PR open (by SURF) at https://github.com/easybuilders/easybuild-easyconfigs/pull/17604
+    - building required OpenMM 8.0 dependency with CUDA support triggered an Internal Compiler Error (ICE) in GCC
+        - a workaround is in place: disabling use of `-ftree-vectorize` for a particular function
+- work on EasyBuild 5.0 has started
+    - development is being done in separate `5.0.x` branches
+    - hope to release EasyBuild 5.0 by end of 2023
+    - will include some breaking changes, like dropping support for Python 2.7 + 3.5
+        - see https://github.com/easybuilders/easybuild-framework/pull/4229
+    - there will be a talk at EUM'23 that covers the planned changes: https://easybuild.io/eum23/#easybuild5
+- Steven: can't get ABAQUS GUI started for recent versions (>= 2019)
+    - same problem on HPC-UGent
+    - works fine with ABAQUS 2018.*

--- a/meeting-notes/2023/2023-05-11.md
+++ b/meeting-notes/2023/2023-05-11.md
@@ -1,0 +1,50 @@
+## Sync meeting 2023-05-11 (09:00 CEST)
+
+- attending: Kenneth, Balazs, Robin, Mag, Alex, Steven, Sam, Maxime
+- no attending: ?
+
+### Agenda
+
+- branch setup in vsc-software-stack repo
+    - keep 'wip' branch as default (most active)
+    - 'vsc' branch for production stuff that can't go to central easyconfigs repo
+    - site branches: site-ugent, site-vub, site-ua, site-kul
+    - README should go in all branches (and be kept in sync)
+        - see README in 'vsc' branch
+    - top of README can have short description on what branch is intended for
+- easystack files + use bot to build & deploy
+    - UGent plans to keep track of software stack in easystack files - see https://docs.easybuild.io/easystack-files
+    - cfr. EESSI bot being developed - https://eessi.github.io/docs/meetings/2022-09-amsterdam/EESSI-community-meeting-2022.09-015-status-build-deploy-bot.pdf
+- running easyconfig tests in 'vsc' branch
+    - GitHub Action workflow to copy 'vsc' branch on top of central 'develop' branch + run test suite
+- EasyBuild v4.7.2 release soon
+    - will include new generic easyblocks for Rust software
+    - see https://github.com/easybuilders/easybuild-easyblocks/pull/2902
+    - easyconfigs using this:
+        - bamtofastq: https://github.com/easybuilders/easybuild-easyconfigs/pull/17595
+        - Longshot: https://github.com/easybuilders/easybuild-easyconfigs/pull/17666
+- Why is there no FFTW.MPI easyconfigs for intel toolchain?
+    - in foss:
+        - FFTW with GCC toolchain + FFTW.MPI with gompi toolchain
+    - in intel (currently):
+        - only FFTW with iimpi toolchain (incl. FFTW MPI routines)
+        - we could have FFTW with intel-compilers toolchain + FFTW.MPI with iimpi toolchain
+    - graph of toolchains and subtoolchains is being added to EasyBuild docs, see https://github.com/easybuilders/easybuild-docs/pull/149/files#r1189519923
+- KUL is upgrading Genius to Rocky 8, would like to keep 2018a + 2019b (+ 2021a) toolchains
+    - will be painful, especially for intel/2018a
+    - there may be some trouble with OpenMPI 3.x?
+        - out-of-memory problem with OpenFOAM on top of OpenMPI 3.x, dies with core dump
+    - effort already done by KUL, could be useful to others?
+        - would be nice if this is shared in site-kul branch in vsc-software-stack
+    - UGent also has some workarounds for RHEL8 in private 'software-stack' repo that could be shared via site-ugent branch in vsc-software-stack
+        - in `intel/2019b` and `intel/2020a`, bump to newer impi:
+        ```
+        # custom impi version for iimpi/2019b on RHEL8 (standard iimpi/2019b has impi 2018.5.288),
+        # because mpirun provided by impi 2018.5.288 crashes during sanity check ("EXIT CODE: 11" => segfault?);
+        # impi 2019.7.217 works for most stuff, but fails with "pthread_mutex_destroy: Device or resource busy"
+        # for some stuff, like Theano, netcdf4-python
+        ('impi', '2019.9.304', '', ('iccifort', local_compver)),
+        ```
+    - VUB is also planning to move to Rocky 8
+- Results of EasyBuild user survey: https://docs.easybuild.io/user-survey/
+    - see OS results @ https://docs.easybuild.io/user-survey/#operating-system

--- a/meeting-notes/README.md
+++ b/meeting-notes/README.md
@@ -1,0 +1,2 @@
+This directory includes snapshots of meeting notes,
+taken from https://hackmd.io/Zr12PpmqRaW_SxeE6SU1lg shortly after a meeting.


### PR DESCRIPTION
Meeting notes were in `main` branch before, but that will be cleaned out, and `vsc` branch is the right place for them (I'll remove them from `wip` branch).

Also includes notes of today's sync meeting (11 May'23)