### PR TITLE
add bundle for CESM: CESM-2-foss-2021b.eb

### DIFF
--- a/c/CESM/CESM-2-foss-2021b.eb
+++ b/c/CESM/CESM-2-foss-2021b.eb
@@ -1,0 +1,19 @@
+easyblock = 'Bundle'
+
+name = 'CESM'
+version = '2'
+
+homepage = 'http://www.cesm.ucar.edu/models/cesm2/'
+description = "Bundle of tools to perform post-processing tasks on CESM data."
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('CESM-deps', '2'),
+    ('NCO', '5.0.3'),
+    ('CDO', '2.0.5'),
+    ('ncview', '2.1.8'),
+]
+
+moduleclass = 'geo'


### PR DESCRIPTION
We made this module for the climate group in VUB. They wanted a module called `CESM` with some extra packages that are convenient in their workflow with CESM but that are not dependencies to it.

Since this easyconfig is too specific to the needs of our users to be pushed upstream to EasyBuild, the `vsc` branch is a good place to keep it.

(note: I'll keep this as a draft until I finish the GH action for this branch)