### PR TITLE
Add DOLFIN-20230817 easyconfigs

### DIFF
--- a/d/DOLFIN/DOLFIN-20230817-foss-2021a-Python-3.9.5-SuperLU_DIST.eb
+++ b/d/DOLFIN/DOLFIN-20230817-foss-2021a-Python-3.9.5-SuperLU_DIST.eb
@@ -1,0 +1,67 @@
+name = 'DOLFIN'
+version = '20230817'
+local_pysuffix = '-Python-%(pyver)s'
+local_petscsuffix =  '-SuperLU_DIST'
+versionsuffix = local_pysuffix + local_petscsuffix
+
+homepage = 'https://bitbucket.org/fenics-project/dolfin'
+description = """DOLFIN is the C++/Python interface of FEniCS, providing a consistent PSE
+  (Problem Solving Environment) for ordinary and partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'usempi': True, 'pic': True, 'packed-linker-options': True, 'openmp': True}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://bitbucket.org/fenics-project',
+        'repo_name': 'dolfin',
+        'commit': 'fd662e',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+patches = [
+#    'DOLFIN_boost-endian.patch',
+    'DOLFIN_boost-algorithm.patch',
+]
+checksums = [
+    {'DOLFIN-20230817.tar.gz': 'a1d2c69e1909d38b9c31e9cd0a92c8b20297fb7fe858cf89130aff06ecf3775b'},
+#    {'DOLFIN_boost-endian.patch': '1555a4ff3cd40a3ccf3dcbd055dded17f0eedcde43190eed79216beb8303099f'},
+    {'DOLFIN_boost-algorithm.patch': '5fe22210f973d845fe6607d8b13a6278d50206d817d0088274cdd98aa1df9e3b'},
+]
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+    ('pkg-config', '0.29.2'),
+    ('patchelf', '0.12'),
+]
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('Boost.Python', '1.76.0'),
+    ('FFC', version, local_pysuffix),
+    ('SCOTCH', '6.1.0'),
+    ('SuiteSparse', '5.10.1', '-METIS-5.1.0'),
+    ('CGAL', '4.14.3'),
+    ('PETSc', '3.15.1', local_petscsuffix),
+    ('SLEPc', '3.15.1', local_petscsuffix),
+    ('HDF5', '1.10.7'),
+    ('zlib', '1.2.11'),
+    ('libxml2', '2.9.10'),
+    ('Eigen', '3.3.9'),
+    ('PLY', '3.11', local_pysuffix),
+    ('petsc4py', '3.15.0', local_petscsuffix),
+    ('pybind11', '2.6.2'),
+    ('slepc4py', '3.15.1', local_petscsuffix),
+    ('ParMETIS', '4.0.3'),
+    ('pkgconfig', '1.5.4', '', ('GCCcore', '10.3.0-python')),
+]
+
+# demos run as tests fail with 'bad X server connection', skipping for now
+runtest = False
+
+# strip out too strict version requirement for pybind11
+#preinstallopts = "sed -i 's/pybind11==[0-9.]*/pybind11/g' %(builddir)s/dolfin-%(version)s/python/setup.py && "
+
+moduleclass = 'math'

--- a/d/DOLFIN/DOLFIN_boost-algorithm.patch
+++ b/d/DOLFIN/DOLFIN_boost-algorithm.patch
@@ -1,0 +1,11 @@
+diff -Nru dolfin-2018.1.0.post1.orig/dolfin/geometry/IntersectionConstruction.cpp dolfin-2018.1.0.post1/dolfin/geometry/IntersectionConstruction.cpp
+--- dolfin-2018.1.0.post1.orig/dolfin/geometry/IntersectionConstruction.cpp     2022-07-07 15:36:07.363802000 +0200
++++ dolfin-2018.1.0.post1/dolfin/geometry/IntersectionConstruction.cpp  2022-07-07 15:37:12.560720000 +0200
+@@ -18,6 +18,7 @@
+ // First added:  2014-02-03
+ // Last changed: 2017-12-12
+
++#include <algorithm>
+ #include <iomanip>
+ #include <dolfin/mesh/MeshEntity.h>
+ #include "predicates.h"

--- a/d/DOLFIN/dolfin.py
+++ b/d/DOLFIN/dolfin.py
@@ -1,0 +1,361 @@
+##
+# Copyright 2009-2022 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for DOLFIN, implemented as an easyblock
+
+@author: Kenneth Hoste (Ghent University)
+@author: Jens Timmerman (Ghent University)
+"""
+import glob
+import os
+import re
+import tempfile
+from distutils.version import LooseVersion
+
+import easybuild.tools.environment as env
+import easybuild.tools.toolchain as toolchain
+from easybuild.easyblocks.generic.cmakepythonpackage import CMakePythonPackage
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import change_dir, remove
+from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_shared_lib_ext
+
+
+class EB_DOLFIN(CMakePythonPackage):
+    """Support for building and installing DOLFIN."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = CMakePythonPackage.extra_options()
+        extra_vars['separate_build_dir'][0] = True
+        return extra_vars
+
+    def __init__(self, *args, **kwargs):
+        """Initialize class variables."""
+        super(EB_DOLFIN, self).__init__(*args, **kwargs)
+
+        self.boost_dir = None
+        self.saved_configopts = None
+
+    def configure_step(self):
+        """Set DOLFIN-specific configure options and configure with CMake."""
+
+        shlib_ext = get_shared_lib_ext()
+
+        # compiler flags
+        cflags = os.getenv('CFLAGS')
+        cxxflags = os.getenv('CXXFLAGS')
+        fflags = os.getenv('FFLAGS')
+
+        # fix for "SEEK_SET is #defined but must not be for the C++ binding of MPI. Include mpi.h before stdio.h"
+        if self.toolchain.mpi_family() in [toolchain.INTELMPI, toolchain.MPICH, toolchain.MPICH2, toolchain.MVAPICH2]:
+            cflags += " -DMPICH_IGNORE_CXX_SEEK"
+            cxxflags += " -DMPICH_IGNORE_CXX_SEEK"
+            fflags += " -DMPICH_IGNORE_CXX_SEEK"
+
+        self.cfg.update('configopts', '-DCMAKE_C_FLAGS="%s"' % cflags)
+        self.cfg.update('configopts', '-DCMAKE_CXX_FLAGS="%s"' % cxxflags)
+        self.cfg.update('configopts', '-DCMAKE_Fortran_FLAGS="%s"' % fflags)
+
+        # set correct compilers to be used at runtime
+        self.cfg.update('configopts', '-DMPI_C_COMPILER="$MPICC"')
+        self.cfg.update('configopts', '-DMPI_CXX_COMPILER="$MPICXX"')
+
+        # specify MPI library
+        self.cfg.update('configopts', '-DMPI_COMPILER="%s"' % os.getenv('MPICC'))
+
+        if os.getenv('MPI_LIB_SHARED') and os.getenv('MPI_INC_DIR'):
+            self.cfg.update('configopts', '-DMPI_LIBRARY="%s"' % os.getenv('MPI_LIB_SHARED'))
+            self.cfg.update('configopts', '-DMPI_INCLUDE_PATH="%s"' % os.getenv('MPI_INC_DIR'))
+        else:
+            raise EasyBuildError("MPI_LIB_SHARED or MPI_INC_DIR not set, could not determine MPI-related paths.")
+
+        # save config options to reuse them later (e.g. for sanity check commands)
+        self.saved_configopts = self.cfg['configopts']
+
+        # make sure that required dependencies are loaded
+        #deps = ['Boost', 'CGAL', 'ParMETIS', 'PETSc', 'Python',
+        #        'SCOTCH', 'SLEPc', 'SuiteSparse', 'Trilinos', 'zlib']
+        deps = ['Boost', 'CGAL', 'ParMETIS', 'PETSc', 'Python',
+                'SCOTCH', 'SLEPc', 'SuiteSparse', 'zlib']  # XXX
+        # Armadillo was replaced by Eigen in v1.3
+        if LooseVersion(self.version) < LooseVersion('1.3'):
+            deps.append('Armadillo')
+        else:
+            deps.append('Eigen')
+
+        # UFC has been integrated into FFC in v1.4, cfr. https://bitbucket.org/fenics-project/ufc-deprecated
+        if LooseVersion(self.version) < LooseVersion('1.4'):
+            deps.append('UFC')
+
+        # PLY, petsc4py, slepc4py are required since v1.5
+        if LooseVersion(self.version) >= LooseVersion('1.5'):
+            deps.extend(['petsc4py', 'PLY', 'slepc4py'])
+
+        # pybind11 is required to build Python bindings since v2018.1
+        if LooseVersion(self.version) >= LooseVersion('2018.1'):
+            deps.append('pybind11')
+
+        depsdict = {}
+        for dep in deps:
+            deproot = get_software_root(dep)
+            if not deproot:
+                raise EasyBuildError("Dependency %s not available.", dep)
+            else:
+                depsdict.update({dep: deproot})
+
+        # zlib
+        self.cfg.update('configopts', '-DZLIB_INCLUDE_DIR=%s' % os.path.join(depsdict['zlib'], "include"))
+        self.cfg.update('configopts', '-DZLIB_LIBRARY=%s' % os.path.join(depsdict['zlib'], "lib", "libz.a"))
+
+        # set correct openmp options
+        openmp = self.toolchain.get_flag('openmp')
+        self.cfg.update('configopts', '-DOpenMP_CXX_FLAGS="%s"' % openmp)
+        self.cfg.update('configopts', '-DOpenMP_C_FLAGS="%s"' % openmp)
+
+        # Boost config parameters
+        self.cfg.update('configopts', "-DBOOST_INCLUDEDIR=%s/include" % depsdict['Boost'])
+        self.cfg.update('configopts', "-DBoost_DEBUG=ON -DBOOST_ROOT=%s" % depsdict['Boost'])
+        self.boost_dir = depsdict['Boost']
+
+        # UFC and Armadillo config params
+        if 'UFC' in depsdict:
+            self.cfg.update('configopts', "-DUFC_DIR=%s" % depsdict['UFC'])
+        if 'Armadillo' in depsdict:
+            self.cfg.update('configopts', "-DARMADILLO_DIR:PATH=%s " % depsdict['Armadillo'])
+
+        # Eigen config params
+        if 'Eigen' in depsdict:
+            self.cfg.update('configopts', "-DEIGEN3_INCLUDE_DIR=%s " % os.path.join(depsdict['Eigen'], 'include'))
+
+        # specify Python paths
+        if LooseVersion(self.version) < LooseVersion('2018.1'):
+            python = depsdict['Python']
+            pyver = '.'.join(get_software_version('Python').split('.')[:2])
+            self.cfg.update('configopts', "-DPYTHON_INCLUDE_PATH=%s/include/python%s" % (python, pyver))
+            self.cfg.update('configopts', "-DPYTHON_LIBRARY=%s/lib/libpython%s.%s" % (python, pyver, shlib_ext))
+
+        # SuiteSparse config params
+        suitesparse = depsdict['SuiteSparse']
+        umfpack_params = [
+            '-DUMFPACK_DIR="%(sp)s/UMFPACK"',
+            '-DUMFPACK_INCLUDE_DIRS="%(sp)s/UMFPACK/include;%(sp)s/UFconfig"',
+            '-DAMD_DIR="%(sp)s/UMFPACK"',
+            '-DCHOLMOD_DIR="%(sp)s/CHOLMOD"',
+            '-DCHOLMOD_INCLUDE_DIRS="%(sp)s/CHOLMOD/include;%(sp)s/UFconfig"',
+            '-DUFCONFIG_DIR="%(sp)s/UFconfig"',
+            '-DCAMD_LIBRARY:PATH="%(sp)s/CAMD/lib/libcamd.a"',
+            '-DCCOLAMD_LIBRARY:PATH="%(sp)s/CCOLAMD/lib/libccolamd.a"',
+            '-DCOLAMD_LIBRARY:PATH="%(sp)s/COLAMD/lib/libcolamd.a"'
+        ]
+
+        self.cfg.update('configopts', ' '.join(umfpack_params) % {'sp': suitesparse})
+
+        # ParMETIS and SCOTCH
+        self.cfg.update('configopts', '-DPARMETIS_DIR="%s"' % depsdict['ParMETIS'])
+        self.cfg.update('configopts', '-DSCOTCH_DIR="%s" -DSCOTCH_DEBUG:BOOL=ON' % depsdict['SCOTCH'])
+
+        # BLACS and LAPACK
+        self.cfg.update('configopts', '-DBLAS_LIBRARIES:PATH="%s"' % os.getenv('LIBBLAS'))
+        self.cfg.update('configopts', '-DLAPACK_LIBRARIES:PATH="%s"' % os.getenv('LIBLAPACK'))
+
+        # CGAL
+        self.cfg.update('configopts', '-DCGAL_DIR:PATH="%s"' % depsdict['CGAL'])
+
+        # PETSc
+        # need to specify PETSC_ARCH explicitely (env var alone is not sufficient)
+        for env_var in ["PETSC_DIR", "PETSC_ARCH"]:
+            val = os.getenv(env_var)
+            if val:
+                self.cfg.update('configopts', '-D%s=%s' % (env_var, val))
+
+        # MTL4
+        if 'MTL4' in depsdict:
+            self.cfg.update('configopts', '-DMTL4_DIR:PATH="%s"' % depsdict['MTL4'])
+
+        # SUNDIALS
+        if 'SUNDIALS' in depsdict:
+            self.cfg.update('configopts', '-DSUNDIALS_DIR:PATH="%s"' % depsdict['SUNDIALS'])
+
+        # configure
+        out = super(EB_DOLFIN, self).configure_step()
+
+        # make sure that all optional packages are found
+        not_found_re = re.compile("The following optional packages could not be found")
+        if not_found_re.search(out):
+            raise EasyBuildError("Optional packages could not be found, this should not happen...")
+
+        # enable verbose build, so we have enough information if something goes wrong
+        self.cfg.update('buildopts', "VERBOSE=1")
+
+    def test_step(self):
+        """Run DOLFIN demos by means of test."""
+
+        if self.cfg['runtest']:
+
+            # set cache/error dirs for Instant
+            tmpdir = tempfile.mkdtemp()
+            instant_cache_dir = os.path.join(tmpdir, '.instant', 'cache')
+            instant_error_dir = os.path.join(tmpdir, '.instant', 'error')
+            try:
+                os.makedirs(instant_cache_dir)
+                os.makedirs(instant_error_dir)
+            except OSError as err:
+                raise EasyBuildError("Failed to create Instant cache/error dirs: %s", err)
+
+            env_vars = [
+                ('INSTANT_CACHE_DIR', instant_cache_dir),
+                ('INSTANT_ERROR_DIR', instant_error_dir),
+            ]
+            env_var_cmds = ' && '.join(['export %s="%s"' % (var, val) for (var, val) in env_vars])
+
+            cpp_cmds = [
+                env_var_cmds,
+                "cd %(dir)s",
+            ]
+            if LooseVersion(self.version) < LooseVersion('1.1'):
+                cpp_cmds.append("cmake . %s" % self.saved_configopts)
+
+            cpp_cmds.extend([
+                "make VERBOSE=1",
+                "./demo_%(name)s",
+                "cd -",
+            ])
+            cmd_template_cpp = " && ".join(cpp_cmds)
+
+            # list based on demos available for DOLFIN v1.0.0
+            pde_demos = ['biharmonic', 'cahn-hilliard', 'hyperelasticity', 'mixed-poisson',
+                         'navier-stokes', 'poisson', 'stokes-iterative']
+
+            if LooseVersion(self.version) < LooseVersion('1.1'):
+                demos = [os.path.join('demo', 'la', 'eigenvalue')] + [os.path.join('demo', 'pde', x) for x in pde_demos]
+            else:
+                # verified with v1.6.0
+                demos = [os.path.join('demo', 'documented', x) for x in pde_demos]
+
+            # construct commands
+            cmds = [tmpl % {'dir': os.path.join(d, subdir), 'name': os.path.basename(d)}
+                    for d in demos for (tmpl, subdir) in [(cmd_template_cpp, 'cpp')]]
+
+            # exclude Python tests for now, because they 'hang' sometimes (unclear why)
+            # they can be reinstated once run_cmd (or its equivalent) has support for timeouts
+            # see https://github.com/easybuilders/easybuild-framework/issues/581
+            # test command templates
+            # cmd_template_python = " && ".join([
+            #     env_var_cmds,
+            #     "cd %(dir)s",
+            #     "python demo_%(name)s.py",
+            #     "cd -",
+            # ])
+
+            # for (tmpl, subdir) in [(cmd_template_python, 'python'), (cmd_template_cpp, 'cpp')]
+
+            # subdomains-poisson has no C++ get_version, only Python
+            # Python tests excluded, see above
+            # name = 'subdomains-poisson'
+            # path = os.path.join('demo', 'pde', name, 'python')
+            # cmds += [cmd_template_python % {'dir': path, 'name': name}]
+
+            # supply empty argument to each command
+            for cmd in cmds:
+                run_cmd(cmd, log_all=True)
+
+            # clean up temporary dir
+            remove(tmpdir)
+
+    def install_step(self):
+        """Custom install procedure for DOLFIN: also install Python bindings."""
+        super(EB_DOLFIN, self).install_step()
+
+        # avoid that pip (ab)uses $HOME/.cache/pip
+        # cfr. https://pip.pypa.io/en/stable/reference/pip_install/#caching
+        env.setvar('XDG_CACHE_HOME', tempfile.gettempdir())
+        self.log.info("Using %s as pip cache directory", os.environ['XDG_CACHE_HOME'])
+
+        if LooseVersion(self.version) >= LooseVersion('2018.1'):
+            # see https://bitbucket.org/fenics-project/dolfin/issues/897/switch-from-swig-to-pybind11-for-python
+            # and https://github.com/FEniCS/dolfin/blob/master/python/README.rst
+            cwd = change_dir(os.path.join(self.start_dir, 'python'))
+
+            env.setvar('CMAKE_PREFIX_PATH', self.installdir)
+            env.setvar('PYBIND11_DIR', get_software_root('pybind11'))
+
+            run_cmd("pip install --prefix %s ." % self.installdir)
+
+            change_dir(cwd)
+
+    def post_install_step(self):
+        """Post install actions: extend RPATH paths in .so libraries part of the DOLFIN Python package."""
+        if LooseVersion(self.version) >= LooseVersion('1.1'):
+            # cfr. https://github.com/hashdist/hashstack/blob/master/pkgs/dolfin/dolfin.yaml (look for patchelf)
+
+            # determine location of libdolfin.so
+            dolfin_lib = 'libdolfin.so'
+            dolfin_libdir = None
+            for libdir in ['lib', 'lib64']:
+                if os.path.exists(os.path.join(self.installdir, libdir, dolfin_lib)):
+                    dolfin_libdir = os.path.join(self.installdir, libdir)
+                    break
+            if dolfin_libdir is None:
+                raise EasyBuildError("Failed to locate %s", dolfin_lib)
+
+            for pylibdir in self.all_pylibdirs:
+                libs = glob.glob(os.path.join(self.installdir, pylibdir, 'dolfin', 'cpp', '_*.so'))
+                for lib in libs:
+                    out, _ = run_cmd("patchelf --print-rpath %s" % lib, simple=False, log_all=True)
+                    curr_rpath = out.strip()
+                    cmd = "patchelf --set-rpath '%s:%s' %s" % (curr_rpath, dolfin_libdir, lib)
+                    run_cmd(cmd, log_all=True)
+
+    def make_module_extra(self):
+        """Set extra environment variables for DOLFIN."""
+
+        txt = super(EB_DOLFIN, self).make_module_extra()
+
+        # Dolfin needs to find Boost
+        # check whether boost_dir is defined for compatibility with --module-only
+        if self.boost_dir:
+            txt += self.module_generator.set_environment('BOOST_DIR', self.boost_dir)
+
+        envvars = ['I_MPI_CXX', 'I_MPI_CC']
+        for envvar in envvars:
+            envar_val = os.getenv(envvar)
+            # if environment variable is set, also set it in module
+            if envar_val:
+                txt += self.module_generator.set_environment(envvar, envar_val)
+
+        return txt
+
+    def sanity_check_step(self):
+        """Custom sanity check for DOLFIN."""
+
+        # custom sanity check paths
+        custom_paths = {
+            'files': ['bin/dolfin-%s' % x for x in ['version', 'convert', 'order', 'plot']] + ['include/dolfin.h'],
+            'dirs': ['%s/dolfin' % self.pylibdir],
+        }
+
+        super(EB_DOLFIN, self).sanity_check_step(custom_paths=custom_paths)

--- a/d/dijitso/dijitso-20230817-foss-2021a-Python-3.9.5.eb
+++ b/d/dijitso/dijitso-20230817-foss-2021a-Python-3.9.5.eb
@@ -1,0 +1,40 @@
+easyblock = 'PythonPackage'
+
+name = 'dijitso'
+version = '20230817'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://bitbucket.org/fenics-project/dijitso'
+description = "dijitso is a Python module for distributed just-in-time shared library building."
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://bitbucket.org/fenics-project',
+        'repo_name': 'dijitso',
+        'commit': 'c92dcb0',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+checksums = ['7123c511e20dcec698b2c94a8057d714c0892e677c28ef72f2294cf7ff15cf4b']
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('SciPy-bundle', '2021.05'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/dijitso'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["dijitso --help"]
+
+moduleclass = 'math'

--- a/f/FFC/FFC-20230817-foss-2021a-Python-3.9.5.eb
+++ b/f/FFC/FFC-20230817-foss-2021a-Python-3.9.5.eb
@@ -1,0 +1,42 @@
+easyblock = 'PythonPackage'
+
+name = 'FFC'
+version = '20230817'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://bitbucket.org/fenics-project/ffc'
+description = "The FEniCS Form Compiler (FFC) is a compiler for finite element variational forms."
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://bitbucket.org/fenics-project',
+        'repo_name': 'FFC',
+        'commit': '72129fd',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+checksums = ['6403962a5bcf5c56315576166005ba1d9c8c455ca93300c271e93a53cc982aea']
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('UFL', version, versionsuffix),
+    ('FIAT', version, versionsuffix),
+    ('dijitso', version, versionsuffix),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': ['bin/ffc'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["ffc --help"]
+
+moduleclass = 'math'

--- a/f/FIAT/FIAT-20230817-foss-2021a-Python-3.9.5.eb
+++ b/f/FIAT/FIAT-20230817-foss-2021a-Python-3.9.5.eb
@@ -1,0 +1,40 @@
+easyblock = 'PythonPackage'
+
+name = 'FIAT'
+version = '20230817'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://bitbucket.org/fenics-project/fiat'
+description = """The FInite element Automatic Tabulator (FIAT) supports
+generation of arbitrary order instances of the Lagrange elements on
+lines, triangles, and tetrahedra. It is also capable of generating
+arbitrary order instances of Jacobi-type quadrature rules on the same
+element shapes."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/FEniCS',
+        'repo_name': 'fiat',
+        'commit': '7d418fa',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+checksums = ['3324e8c9290d019c362466845f1233b7dc7f8a978d86c84fb2c6021333e20b37']
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('SciPy-bundle', '2021.05'),
+    ('sympy', '1.8'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+options = {'modulename': 'FIAT'}
+
+moduleclass = 'math'

--- a/m/mshr/mshr-20230817-foss-2021a-Python-3.9.5.eb
+++ b/m/mshr/mshr-20230817-foss-2021a-Python-3.9.5.eb
@@ -1,0 +1,50 @@
+easyblock = 'CMakeMake'
+
+name = 'mshr'
+version = '20230817'
+local_pysuffix = '-Python-%(pyver)s'
+local_petscsuffix =  '-SuperLU_DIST'
+versionsuffix = local_pysuffix + local_petscsuffix
+
+homepage = 'https://bitbucket.org/fenics-project/mshr'
+description = "mshr is the mesh generation component of FEniCS. It generates simplicial DOLFIN meshes in 2D and 3D from geometries described by Constructive Solid Geometry (CSG) or from surface files, utilizing CGAL and Tetgen as mesh generation backends."
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://bitbucket.org/fenics-project',
+        'repo_name': 'mshr',
+        'commit': 'c27eb18',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+patches = ['mshr_fix-cgal-mesh3.patch']
+checksums = [
+    {'mshr-20230817.tar.gz': 'b610740e279e66ed1fd9d7ac845e745eaeb5a758b720379b4edc9d0e497713cf'},
+    {'mshr_fix-cgal-mesh3.patch': '5e777d20f8cd5cb889cdb553f70fd1e74d852ad887ac7779590da63b8820eda1'},
+]
+
+builddependencies = [('CMake', '3.20.1')]
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('DOLFIN', version, versionsuffix),
+    ('CGAL', '4.14.3'),
+    ('GMP', '6.2.1'),
+    ('TetGen', '1.6.0'),
+]
+
+configopts = '-DUSE_SYSTEM_CGAL=TRUE '
+configopts += '-DCMAKE_BUILD_TYPE="Release" '
+
+sanity_check_paths = {
+    'files': ['lib/libmshr.so'],
+    'dirs': ['lib'],
+}
+
+modextravars = {'CGAL_MODULES_DIR': '${EBROOTCGAL}'}
+
+moduleclass = 'numlib'

--- a/m/mshr/mshr_fix-cgal-mesh3.patch
+++ b/m/mshr/mshr_fix-cgal-mesh3.patch
@@ -1,0 +1,26 @@
+diff -ruN mshr.orig/src/make_multicomponent_mesh_3.h mshr/src/make_multicomponent_mesh_3.h
+--- mshr.orig/src/make_multicomponent_mesh_3.h	2023-08-18 10:34:52.000000000 +0200
++++ mshr/src/make_multicomponent_mesh_3.h	2023-08-18 10:55:10.983348000 +0200
+@@ -37,11 +37,11 @@
+   //std::cout << "Number of vertices initially: " << c3t3.triangulation().number_of_vertices() << std::endl;
+ 
+   // Initialize c3t3 with points from the special features
+-  CGAL::internal::Mesh_3::C3t3_initializer< 
++  CGAL::Mesh_3::internal::C3t3_initializer< 
+     C3T3,
+     MeshDomain,
+     MeshCriteria,
+-    CGAL::internal::Mesh_3::has_Has_features<MeshDomain>::value > () (c3t3,
++    CGAL::Mesh_3::internal::has_Has_features<MeshDomain>::value > () (c3t3,
+                                                                       domain,
+                                                                       criteria,
+                                                                       with_features);
+@@ -49,7 +49,7 @@
+   // std::cout << "Number of vertices after features: " << c3t3.triangulation().number_of_vertices() << std::endl;
+   
+   // Inserts points from all connected components to the mesh
+-  CGAL::internal::Mesh_3::init_c3t3(c3t3, domain, criteria, 0);
++  CGAL::Mesh_3::internal::init_c3t3(c3t3, domain, criteria, 0);
+   // std::cout << "Number of vertices before meshing: " << c3t3.triangulation().number_of_vertices() << std::endl;
+   
+   // Build mesher and launch refinement process

--- a/u/UFL/UFL-20230817-foss-2021a-Python-3.9.5.eb
+++ b/u/UFL/UFL-20230817-foss-2021a-Python-3.9.5.eb
@@ -1,0 +1,38 @@
+easyblock = 'PythonPackage'
+
+name = 'UFL'
+version = '20230817'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://bitbucket.org/fenics-project/ufl'
+description = """The Unified Form Language (UFL) is a domain specific language 
+ for declaration of finite element discretizations of variational forms. 
+ More precisely, it defines a flexible interface for choosing finite element 
+ spaces and defining expressions for weak forms in a notation close to 
+ mathematical notation."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/FEniCS',
+        'repo_name': 'ufl',
+        'commit': '20a231f',
+        'recursive': True,
+        'keep_git_dir': True,
+    },
+}]
+checksums = ['532d8eab22d992b76856c401dc55ff6dfa44267bddd492ca7b37035d86be973a']
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('SciPy-bundle', '2021.05'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+options = {'modulename': 'ufl_legacy'}
+
+moduleclass = 'cae'


### PR DESCRIPTION
Geert Buckinx requested a new DOLFIN installation which has some bugfixes compared to ` 2019.1.0.post0-foss-2021a-Python-3.9.5-SuperLU_DIST`, but is otherwise installed in the same way. The version he refers to is `2019.2.0.dev0`, but unfortunately there is no release with that name and there are multiple commits that share that version name. So I tried to select a set of recent commits from the different fenics components that are compatible with each other, and the result is in this PR.

One thing I am not sure about yet is how to deal with the customization of the `dolfin.py` easyblock. I included it here, but this will become problematic in case we need multiple customized `dolfin.py` easyblocks.