### PR TITLE
Add pharmacology packages

### DIFF
--- a/n/NONMEM/NONMEM-7.5.0-GCC-10.3.0-MPICH-3.4.2.eb
+++ b/n/NONMEM/NONMEM-7.5.0-GCC-10.3.0-MPICH-3.4.2.eb
@@ -1,0 +1,89 @@
+easyblock = 'CmdCp'
+
+name = 'NONMEM'
+version = '7.5.0'
+
+local_mpichver = '3.4.2'
+versionsuffix = '-MPICH-%s' % local_mpichver
+
+homepage = 'https://www.iconplc.com/innovation/nonmem/'
+description = """NONMEM is a non-linear mixed-effects modeling software package."""
+
+toolchain = {'name': 'GCC', 'version': '10.3.0'}
+
+local_majminver = '%(version_major)s%(version_minor)s'
+local_nmbin = 'nmfe%s' % local_majminver
+
+# You'll need to download the (password-protected) NONMEMXXX.zip file first from
+# https://nonmem.iconplc.com/#/nonmemXXX (which, for v7.5.0, should have the
+# 221f6f11205396997d1d135807635c3a3d2f0ed97fc6cce50461724b5181d166 checksum)
+# and then recompress
+sources = [SOURCE_TAR_GZ]
+
+patches = [
+    'NONMEM-7.5.0-std-legacy-gfortran.patch',
+]
+
+checksums = [
+    None,
+    '108efc6c05bd9188bac4d9d71e7ea2ddc873cc4de0eb3af13317acf14f8a47d4',  # NONMEM-7.5.0-std-legacy-gfortran.patch
+]
+
+dependencies = [
+    ('MPICH', local_mpichver),
+]
+
+# We need to build in the installdir because of non-relative paths in the build artifacts
+local_build_cmd = './SETUP{0} {1} %(installdir)s gfortran y ar same rec q unzip {2}{0}e.zip {2}{0}r.zip && '.format(
+                  local_majminver, '${PWD}', '%(namelower)s')
+
+# For MPI support, additional files need to be copied and (re)compiled:
+local_build_cmd += 'cp ${EBROOTMPICH}/include/mpi.mod %(installdir)s/mpi/mpi_ling && '
+local_build_cmd += 'cp ${EBROOTMPICH}/include/mpi.mod %(installdir)s/resource && '
+local_build_cmd += 'cp ${EBROOTMPICH}/lib/libmpi.a %(installdir)s/mpi/mpi_ling/libmpich.a && '
+local_build_cmd += 'cd %(installdir)s/mpi/mpi_ling && '
+local_fflags = '-w -O3 -ffast-math -std=legacy -ffpe-summary=none -xf95'
+local_build_cmd += 'mpif90 {0} -I../../resource -c PNM_MPI.f90 && '.format(local_fflags)
+local_build_cmd += 'mpif90 {0} -I../../resource -c PNM_MPID.f90 && '.format(local_fflags)
+local_build_cmd += 'mpif90 {0} -fno-range-check  -I../../resource -c MPI.f90 && '.format(local_fflags)
+
+# Modifying the mpif90 and mpirun calls in the runscripts so that NONMEM can be used
+# together with modules which load different MPI modules (e.g. PsN)
+local_build_cmd += 'cd %(installdir)s && '
+local_build_cmd += 'sed -i "s@mpif90@$(which mpif90)@g" '
+local_build_cmd += 'util/{0} util/{0}original util/nmfePDx run/{0} run/nmfePDx && '.format(local_nmbin)
+local_build_cmd += 'sed -i "s@mpirun@mpiexec.hydra@g" '
+local_build_cmd += 'runfiles/mpilinux8.pnm runfiles/mpilinux_onecomputer.pnm runfiles/mpilinux_twocomputers.pnm '
+local_build_cmd += 'run/mpilinux8.pnm run/mpilinux_onecomputer.pnm run/mpilinux_twocomputers.pnm '
+
+cmds_map = [('.*', local_build_cmd)]
+
+modextrapaths = {
+    'PATH': 'run',
+}
+
+# No files to copy since the build needed to be done in the installdir
+# The install step then needs to be skipped to keep the installdir contents
+files_to_copy = []
+skipsteps = ['install']
+
+sanity_check_paths = {
+    'files': [
+        'run/%s' % local_nmbin,
+        'run/%(namelower)s',
+        'tr/NMTRAN.exe',
+    ],
+    'dirs': [
+        'help',
+        'mpi',
+        'util',
+    ],
+}
+
+sanity_check_commands = [
+    '%s | grep Usage' % local_nmbin,
+]
+
+# After installation, a license file needs to be copied to ${EBROOTNONMEM}/license/nonmem.lic
+
+moduleclass = 'bio'

--- a/n/NONMEM/NONMEM-7.5.0-std-legacy-gfortran.patch
+++ b/n/NONMEM/NONMEM-7.5.0-std-legacy-gfortran.patch
@@ -1,0 +1,13 @@
+# The source contains non-conforming Fortran code,
+# so gfortran needs the -std=legacy option
+--- nm750CD/SETUP75_orig	2023-07-27 10:11:44.172408000 +0200
++++ nm750CD/SETUP75	2023-07-27 10:12:01.958492000 +0200
+@@ -404,7 +404,7 @@
+ echo "end" >>dummyfile.f90
+ gfortran -c dummyfile.f90 -ffpe-summary=none  >trash.txt 2>&1
+ if [ $? == 0 ]; then fpesummary="-ffpe-summary=none"; fi
+-op="-w -O3 -ffast-math ""$fpesummary"
++op="-w -O3 -ffast-math -std=legacy ""$fpesummary"
+ fi
+ 
+ if [[ $os == Darwin && $ftail == gfortran ]]; then op="$op ""$m" ; fi

--- a/p/Pirana/Dockerfile.pirana
+++ b/p/Pirana/Dockerfile.pirana
@@ -1,0 +1,71 @@
+FROM ubuntu:22.04
+
+# Base packages
+RUN apt -y update
+RUN apt -y install make wget vim
+RUN apt -y install gcc build-essential
+RUN apt -y install libx11-dev xterm perl cpanminus libxml2-dev
+RUN apt -y install libpng-dev
+RUN apt -y install mousepad
+
+# R4.x installation instructions based on
+# https://cran.r-project.org/bin/linux/ubuntu/
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt -y update -qq
+RUN apt -y install --no-install-recommends software-properties-common dirmngr
+RUN wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+RUN add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+RUN apt -y install --no-install-recommends r-base
+
+RUN mkdir /perl_modules
+RUN cpanm -v -L /perl_modules local::lib
+RUN cpanm -v -L /perl_modules threads
+RUN cpanm -v -L /perl_modules threads::shared
+RUN cpanm -v -L /perl_modules Data::Dumper@2.183
+RUN cpanm -v -L /perl_modules Log::Log4perl@1.54
+RUN cpanm -v -L /perl_modules Log::Dispatch::FileRotate@1.38
+RUN cpanm -v -L /perl_modules Config::Simple@4.58
+RUN cpanm -v -L /perl_modules Text::Diff@1.45
+RUN cpanm -v -L /perl_modules Text::Diff::HTML@0.08
+RUN cpanm -v -L /perl_modules Text::Table@1.134
+RUN cpanm -v -L /perl_modules Tk@804.035
+RUN cpanm -v -L /perl_modules Tk::ItemStyle@4.004
+RUN cpanm -v -L /perl_modules Tk::Pane@4.007
+RUN cpanm -v -L /perl_modules Tk::Splashscreen@1.0
+RUN cpanm -v -L /perl_modules --force Tk::JComboBox@1.14
+RUN cpanm -v -L /perl_modules Tk::PlotDataset@2.05
+RUN cpanm -v -L /perl_modules Tk::HdrResizeButton@1.5
+RUN cpanm -v -L /perl_modules Net::EmptyPort
+RUN cpanm -v -L /perl_modules File::Copy@2.35
+RUN cpanm -v -L /perl_modules File::Copy::Recursive@0.45
+RUN cpanm -v -L /perl_modules Crypt::CBC@2.33
+RUN cpanm -v -L /perl_modules Crypt::Cipher::DES@0.072
+RUN cpanm -v -L /perl_modules DBI@1.643
+RUN cpanm -v -L /perl_modules DBD::SQLite@1.66
+RUN cpanm -v -L /perl_modules Archive::Zip@1.68
+RUN cpanm -v -L /perl_modules Image::Size@3.300
+RUN cpanm -v -L /perl_modules XML::TreePP@0.43
+RUN cpanm -v -L /perl_modules HTTP::Date@6.05
+RUN cpanm -v -L /perl_modules Statistics::R@0.34
+RUN cpanm -v -L /perl_modules Date::Parse@2.33
+RUN cpanm -v -L /perl_modules Storable@3.15
+RUN cpanm -v -L /perl_modules List::MoreUtils@0.430
+RUN cpanm -v -L /perl_modules Test::Most
+RUN cpanm -v -L /perl_modules Test::Files
+# This one is not mentioned in the docs, but does seem necessary:
+RUN cpanm -v -L /perl_modules Nice::Try
+
+ENV PERL5LIB /perl_modules/lib/perl5
+ENV PIRANA_LOCALLIB /perl_modules
+
+# RsNLME installation
+RUN apt -y install grep pkg-config libfontconfig1-dev gzip
+RUN apt -y install libcurl4-openssl-dev libssl-dev libssh-dev
+RUN apt -y install liblapack-dev libblas-dev gfortran
+
+RUN R -e 'Certara_Packages <- c("Certara.RsNLME", "Certara.NLME8", "Certara.Xpose.NLME", "Certara.RsNLME.ModelExecutor", "Certara.RsNLME.ModelBuilder"); install.packages(Certara_Packages, repos=c("https://certara.jfrog.io/artifactory/certara-cran-release-public/", "https://cloud.r-project.org"))'
+
+RUN apt -y install mupdf
+RUN xdg-mime default mupdf.desktop application/pdf
+
+WORKDIR /

--- a/p/Pirana/Pirana-3.0.0-singularity.eb
+++ b/p/Pirana/Pirana-3.0.0-singularity.eb
@@ -20,7 +20,7 @@ sources = [
     },
 ]
 
-checksums = ['23f4999f9a6314eaa1744823ab4d6f79e090922b6309ef2740fcedb9d5f9de89']
+checksums = [None]
 
 skipsteps = ['build']
 

--- a/p/Pirana/Pirana-3.0.0-singularity.eb
+++ b/p/Pirana/Pirana-3.0.0-singularity.eb
@@ -14,6 +14,7 @@ local_img_name = '%(namelower)s.sif'
 sources = [
     {
         # This Singularity image needs to be in your sources folder
+        # (corresponding Dockerfile included here as "Dockerfile.pirana")
         'filename': local_img_name,
         'extract_cmd': 'cp %s %(builddir)s',
     },

--- a/p/Pirana/Pirana-3.0.0-singularity.eb
+++ b/p/Pirana/Pirana-3.0.0-singularity.eb
@@ -28,12 +28,22 @@ files_to_copy = [
     ([local_img_name], 'img'),
 ]
 
+local_singularity_custom_args = ''
+# Uncomment to always bind-mount the ${VSC_DATA} directory in the container
+#local_singularity_custom_args += '-B \${VSC_DATA}:\${VSC_DATA} '
+
+local_launch_cmd = 'singularity exec \"\${@:2}\" '
+local_launch_cmd += local_singularity_custom_args
+local_launch_cmd += '%(installdir)s/img/pirana.sif perl \$1'
+
+local_pirana_bin = '%(installdir)s/bin/pirana'
+
 postinstallcmds = [
      # Add a 'pirana' script to make it easier to launch the container
      'mkdir %(installdir)s/bin',
-     'echo "#!/usr/bin/env bash" > %(installdir)s/bin/pirana',
-     'echo "singularity exec -B \${VSC_DATA}:\${VSC_DATA} \"\${@:2}\" %(installdir)s/img/pirana.sif perl \$1" >> %(installdir)s/bin/pirana',
-     'chmod +x %(installdir)s/bin/pirana',
+     'echo "#!/usr/bin/env bash" > %s' % local_pirana_bin,
+     'echo "%s" >> %s' % (local_launch_cmd, local_pirana_bin),
+     'chmod +x %s' % local_pirana_bin,
 ]
 
 sanity_check_paths = {

--- a/p/Pirana/Pirana-3.0.0-singularity.eb
+++ b/p/Pirana/Pirana-3.0.0-singularity.eb
@@ -32,7 +32,7 @@ postinstallcmds = [
      # Add a 'pirana' script to make it easier to launch the container
      'mkdir %(installdir)s/bin',
      'echo "#!/usr/bin/env bash" > %(installdir)s/bin/pirana',
-     'echo "singularity exec -B ${VSC_DATA}:${VSC_DATA} \"${@:2}\" %(installdir)s/img/pirana.sif perl $1" >> %(installdir)s/bin/pirana',
+     'echo "singularity exec -B \${VSC_DATA}:\${VSC_DATA} \"\${@:2}\" %(installdir)s/img/pirana.sif perl \$1" >> %(installdir)s/bin/pirana',
      'chmod +x %(installdir)s/bin/pirana',
 ]
 

--- a/p/Pirana/Pirana-3.0.0-singularity.eb
+++ b/p/Pirana/Pirana-3.0.0-singularity.eb
@@ -1,0 +1,47 @@
+easyblock = 'CmdCp'
+
+name = 'Pirana'
+version = '3.0.0'
+versionsuffix = '-singularity'
+
+homepage = 'https://www.certara.com/software/pirana-modeling-workbench'
+description = """Pirana is a workbench for optimizing pharmacometric workflows. This module provides a Singularity image that can be used to launch the Pirana Linux desktop client (e.g. v21.11.1) by executing 'pirana /user/or/data/path/to/your/Pirana/pirana.pl'"""
+
+toolchain = SYSTEM
+
+local_img_name = '%(namelower)s.sif'
+
+sources = [
+    {
+        # This Singularity image needs to be in your sources folder
+        'filename': local_img_name,
+        'extract_cmd': 'cp %s %(builddir)s',
+    },
+]
+
+checksums = ['23f4999f9a6314eaa1744823ab4d6f79e090922b6309ef2740fcedb9d5f9de89']
+
+skipsteps = ['build']
+
+files_to_copy = [
+    ([local_img_name], 'img'),
+]
+
+postinstallcmds = [
+     # Add a 'pirana' script to make it easier to launch the container
+     'mkdir %(installdir)s/bin',
+     'echo "#!/usr/bin/env bash" > %(installdir)s/bin/pirana',
+     'echo "singularity exec -B ${VSC_DATA}:${VSC_DATA} \"${@:2}\" %(installdir)s/img/pirana.sif perl $1" >> %(installdir)s/bin/pirana',
+     'chmod +x %(installdir)s/bin/pirana',
+]
+
+sanity_check_paths = {
+    'files': ['bin/pirana', 'img/%s' % local_img_name],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    'pirana --version',
+]
+
+moduleclass = 'bio'

--- a/p/PsN/PsN-5.3.0-foss-2021a.eb
+++ b/p/PsN/PsN-5.3.0-foss-2021a.eb
@@ -1,0 +1,140 @@
+easyblock = 'Bundle'
+
+name = 'PsN'
+version = '5.3.0'
+
+homepage = 'https://uupharmacometrics.github.io/PsN/'
+description = """Perl-speaks-NONMEM (PsN) is a collection of Perl modules and programs
+aiding in the development of non-linear mixed effect models using NONMEM."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'usempi': False, 'openmp': False, 'pic': True}
+
+local_perlver = '5.32.1'
+local_perlmajver = local_perlver.split('.')[0]
+local_libdir = 'lib/perl%s/site_perl/%s' % (local_perlmajver, local_perlver)
+
+dependencies = [
+    ('Perl', local_perlver),
+    ('Python', '3.9.5'),
+    ('R', '4.1.0'),
+    ('GMP', '6.2.1'),
+    ('MPFR', '4.1.0'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+exts_classmap = {
+    'Math::Random': 'PerlModule',
+    'MouseX::Params::Validate': 'PerlModule',
+    'Archive::Zip': 'PerlModule',
+    'Devel::Caller': 'PerlModule',
+    'PadWalker': 'PerlModule',
+    name: 'PsN',
+}
+
+exts_list = [
+    ('systemfonts', '1.0.4', {
+        'checksums': ['ef766c75b942f147d382664a00d6a4930f1bfe0cce9d88943f571682a85a84c0'],
+    }),
+    ('svglite', '2.1.0', {
+        'checksums': ['ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b'],
+    }),
+    ('kableExtra', '1.3.4', {
+        'checksums': ['091ffac282cf9257edcec1a06da38b5e6516f111296bedb934e32f5692ffbbb0'],
+    }),
+    ('vpc', '1.2.2', {
+        'checksums': ['33c2e034e9ac944a6682482a8caa0b958b872d4465e34e52119b2b5ca1714997'],
+    }),
+    ('xpose', '0.4.17', {
+        'checksums': ['741f0b7048542b3363f50e0cebb08b9144618bf273fa124de588d1fd12a28225'],
+    }),
+    ('xpose4', '4.7.2', {
+        'checksums': ['51df73c1e26591b83fc709d99c996f8c9c22e00b836fe82ded7eaeb57b8b3991'],
+    }),
+    ('ggthemes', '4.2.4', {
+        'checksums': ['7b35168cf5b68f6f52dd533a1b345ec87e09d1a85ca68e8dc5377cdf95718567'],
+    }),
+    ('vegawidget', '0.4.2', {
+        'checksums': ['9a39664b81f078d640fb67dde5cab4e3a36da252bb5d4fa9e8a2bd102029d966'],
+    }),
+    ('PerformanceAnalytics', '2.0.4', {
+        'checksums': ['78a17070977665b30ddf3999d02fbbcca0f418b0791358c14bdc722235342232'],
+    }),
+    ('vaplot', '0.0.0.9000', {
+        'source_urls': ['https://github.com/rikardn/vaplot/archive/'],
+        'sources': [
+            {
+                'download_filename': 'da3420de63784f6766b455cb684a0d848fedec25.tar.gz',
+                'filename': SOURCE_TAR_GZ,
+            },
+        ],
+        'checksums': ['9a030b44ff6841e219431ddcb0d6483bb659d6ec32cbb8f9fe756e13cddfd312'],
+        # Installing from the extension's directory leads to R CMD INSTALL to use renv
+        # which then fails because it is not finding packages included in the R installation
+        'preinstallopts': 'mkdir build && cd build &&',
+    }),
+    ('Math::Random', '0.72', {
+        'source_tmpl': 'Math-Random-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GROMMEL'],
+        'checksums': ['be0522328811d96de505d9ebac3d096359026fa8d5c38f7bb999a78ec5bc254c'],
+    }),
+    ('MouseX::Params::Validate', '0.10', {
+        'source_tmpl': 'MouseX-Params-Validate-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MANWAR'],
+        'checksums': ['1a58de738b7050ab94549d9009e4e0f9e8129fb4f4c8e0954ae5b30540f665a2'],
+    }),
+    ('Archive::Zip', '1.68', {
+        'source_tmpl': 'Archive-Zip-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PH/PHRED'],
+        'checksums': ['984e185d785baf6129c6e75f8eb44411745ac00bf6122fb1c8e822a3861ec650'],
+    }),
+    ('Devel::Caller', '2.06', {
+        'source_tmpl': 'Devel-Caller-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+        'checksums': ['6a73ae6a292834255b90da9409205425305fcfe994b148dcb6d2d6ef628db7df'],
+    }),
+    ('PadWalker', '2.5', {
+        'source_tmpl': 'PadWalker-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RO/ROBIN'],
+        'checksums': ['07b26abb841146af32072a8d68cb90176ffb176fd9268e6f2f7d106f817a0cd0'],
+    }),
+    (name, version, {
+        'modulename': False,
+        'source_urls': ['https://github.com/UUPharmacometrics/PsN/releases/download/v%(version)s/'],
+        'sources': ['%(name)s-%(version)s.tar.gz'],
+        'patches': ['PsN-5.3.0-keep-Rlibs-site-env.patch'],
+        'checksums': [
+            '98883231329219525436e382e325a1865df9bc7d62fa83081ffb7ee4301b0591',  # PsN-5.3.0.tar.gz
+            '2b22dc0a0cfb4eb419c226e7b857e806886372e2320af801dffbd6ec5f115ba3',  # PsN-5.3.0-keep-Rlibs-site-env.patch
+        ],
+        'perllib': local_libdir,
+        'nm_versions': ['default=nmfe75,7.5', 'nm750=nmfe75,7.5'],
+    }),
+]
+
+modextrapaths = {
+    'PERL5LIB': local_libdir,
+    'R_LIBS_SITE': ['', '%s/%s_%s/Rlib' % (local_libdir, name, version.replace('.', '_'))],
+}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['bin', local_libdir],
+}
+
+sanity_check_commands = [
+    'execute -h',
+    'psn -h',
+    'qa -h',
+    'Rscript -e "library(PsNR)"',
+]
+
+moduleclass = 'bio'

--- a/p/PsN/PsN-5.3.0-keep-Rlibs-site-env.patch
+++ b/p/PsN/PsN-5.3.0-keep-Rlibs-site-env.patch
@@ -1,0 +1,12 @@
+# Don't overwrite the R_LIBS_SITE environment variable,
+# which we need to supply the PsNR dependencies.
+--- PsN-Source/setup.pl_orig    2023-07-25 16:01:59.000000000 +0200
++++ PsN-Source/setup.pl 2023-07-25 16:02:05.000000000 +0200
+@@ -915,7 +915,6 @@
+         my $repos = 'https://cloud.r-project.org';
+         my $rsafe_path = $rlib_path;
+         $rsafe_path =~ s/\\/\\\\/g;
+-        $ENV{'R_LIBS_SITE'} = $rlib_path;
+         $ENV{'R_LIBS_USER'} = $rlib_path;
+         run_r("install.packages(c('renv', 'remotes'), lib='$rsafe_path', repos='$repos')");
+         run_r("options(renv.consent=TRUE); renv::settings" . '\$' . "use.cache(FALSE); renv::restore(library='$rsafe_path', lockfile='PsNR/renv.lock')");

--- a/p/PsN/psn.py
+++ b/p/PsN/psn.py
@@ -1,0 +1,58 @@
+import os
+
+from easybuild.framework.easyconfig import CUSTOM, MANDATORY
+from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.easyblocks.generic.perlmodule import PerlModule
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.modules import get_software_root
+from easybuild.tools.run import run_cmd, run_cmd_qa
+
+
+class PsN(PerlModule):
+    @staticmethod
+    def extra_options():
+        """Easyconfig parameters specific to PsN modules."""
+        extra_vars = {
+            'perllib': [None, "PsN requires 'perllib' parameter", MANDATORY],
+            'nm_versions': [None, "Lines to add to [nm_versions] in psn.conf", CUSTOM],
+        }
+        return ExtensionEasyBlock.extra_options(extra_vars)
+
+    def install_perl_module(self):
+        rlibdir = self.installdir
+        cmd = 'R_LIBS_SITE=%s perl setup.pl' % rlibdir
+
+        bindir = os.path.join(self.installdir, 'bin')
+        libdir = os.path.join(self.installdir, self.cfg['perllib'])
+
+        perlroot = get_software_root('Perl')
+        if perlroot is None:
+            raise EasyBuildError("Perl is a required dependency of PsN")
+        perlbin = os.path.join(perlroot, 'bin', 'perl')
+        perllib = os.path.join(perlroot, self.cfg['perllib'])
+
+        qanda = {
+            'PsN Utilities installation directory [/usr/local/bin]:': bindir,
+            'Path to perl binary used to run Utilities [%s]:' % perlbin: '',
+            'PsN Core and Toolkit installation directory [%s]:' % perllib: libdir,
+            'Would you like this script to check Perl modules [y/n]?': 'y',
+            'Continue installing PsN (installing is possible even if modules are missing)[y/n]?': 'y',
+            'Would you like to install the PsNR R package? [y/n]': 'y',
+            'Would you like to install the pharmpy python package? [y/n]': 'y',
+            'Would you like to install the PsN test library? [y/n]': 'y',
+            'PsN test library installation directory [%s]:' % libdir: '',
+            'Would you like help to create a configuration file? [y/n]': 'n',
+            'Press ENTER to exit the installation program.': '',
+        }
+
+        maxhits = 200  # to give enough time to pharmpy installation
+
+        run_cmd_qa(cmd, qanda, maxhits=maxhits, log_all=True, simple=True)
+
+        # Add selected NONMEM versions to [nm_versions] section in PsN config file
+        if self.cfg['nm_versions'] is not None:
+            lines = r'\n'.join(self.cfg['nm_versions'])
+            PsN_X_Y_Z = '_'.join([self.name] + self.version.split('.'))
+            psnconf = os.path.join(libdir, PsN_X_Y_Z, 'psn.conf')
+            cmd = "sed -i '/\[nm_versions\]/a %s' %s" % (lines, psnconf)
+            run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
~~The first 3 commits add the easyconfigs/blocks for NONMEM/PsN/Pirana which I used for installing the corresponding Rocky 8 modules on Genius. The commits after that refine the Pirana one so that it becomes easier to use for e.g. other sites.~~
This adds add the easyconfigs/blocks for NONMEM/PsN/Pirana used for installing them for Genius/Rocky8.


(For the record: as of yet, none of these packages are included in (upstream) EasyBuild.)