### PR TITLE
Add easyblock and easyconfig for FPC (Free Pascal Compiler)

### DIFF
--- a/f/FPC/FPC-3.2.2.eb
+++ b/f/FPC/FPC-3.2.2.eb
@@ -1,0 +1,22 @@
+name = 'FPC'
+version = '3.2.2'
+
+homepage = 'https://www.freepascal.org/'
+description = """Free Pascal is a mature, versatile, open source Pascal compiler. It can target many processor architectures"""
+
+toolchain = SYSTEM
+
+source_urls = ['http://downloads.freepascal.org/fpc/dist/3.2.2/i386-linux']
+sources = ['fpc-3.2.2.i386-linux.tar']
+checksums = ['f62980ac0b2861221f79fdbff67836aa6912a4256d4192cfa4dfa0ac5b419958']
+
+sanity_check_paths = {
+    'files': ['bin/fpc', 'lib/libpas2jslib.so'],
+    'dirs': ['bin', 'lib'],
+}
+
+sanity_check_commands = [
+    'fpc -iV',
+]
+
+moduleclass = 'compiler'

--- a/f/FPC/FPC-3.2.2.eb
+++ b/f/FPC/FPC-3.2.2.eb
@@ -6,9 +6,9 @@ description = """Free Pascal is a mature, versatile, open source Pascal compiler
 
 toolchain = SYSTEM
 
-source_urls = ['http://downloads.freepascal.org/fpc/dist/3.2.2/i386-linux']
-sources = ['fpc-3.2.2.i386-linux.tar']
-checksums = ['f62980ac0b2861221f79fdbff67836aa6912a4256d4192cfa4dfa0ac5b419958']
+source_urls = ['http://downloads.freepascal.org/fpc/dist/3.2.2/x86_64-linux']
+sources = ['fpc-3.2.2.x86_64-linux.tar']
+checksums = ['5adac308a5534b6a76446d8311fc340747cbb7edeaacfe6b651493ff3fe31e83']
 
 sanity_check_paths = {
     'files': ['bin/fpc', 'lib/libpas2jslib.so'],

--- a/f/FPC/fpc.py
+++ b/f/FPC/fpc.py
@@ -1,0 +1,58 @@
+##
+# Copyright 2009-2023 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for FPC, implemented as an easyblock
+
+@author: Steven Vandenbrande (KU Leuven)
+"""
+from easybuild.easyblocks.generic.binary import Binary
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.modules import get_software_root
+from easybuild.tools.run import run_cmd_qa
+
+
+class EB_FPC(Binary):
+    """Support for installing FPC (Free Pascal Compiler)."""
+
+    def extract_step(self):
+        """Use default extraction procedure instead of the one for the Binary easyblock."""
+        EasyBlock.extract_step(self)
+
+    def install_step(self):
+        """Install FPC using 'install.sh' script."""
+
+        # Simple question-answer pairs
+        qanda = {
+            'Install documentation (Y/n) ?': 'Y',
+            'Install demos (Y/n) ?': 'Y',
+
+        }
+        # Question-answer pairs with regular expressions
+        std_qa = {
+           r'Install prefix \(\/usr or \/usr\/local\)  \[[\S]*\] : ': self.installdir,
+           r'Install demos in[\s\S]*': '',
+        }
+        
+        run_cmd_qa('./install.sh', qanda, std_qa=std_qa, log_all=True, simple=True)

--- a/f/FPC/fpc.py
+++ b/f/FPC/fpc.py
@@ -1,27 +1,3 @@
-##
-# Copyright 2009-2023 Ghent University
-#
-# This file is part of EasyBuild,
-# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
-# with support of Ghent University (http://ugent.be/hpc),
-# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
-# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
-# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
-#
-# https://github.com/easybuilders/easybuild
-#
-# EasyBuild is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation v2.
-#
-# EasyBuild is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
-##
 """
 EasyBuild support for FPC, implemented as an easyblock
 


### PR DESCRIPTION
Installation for FPC was requested in 109544. The developers provide an interactive install script, the easyblock uses `run_cmd_qa` to process that script.