### PR TITLE
Add iCommands easyconfig and its dependencies

### DIFF
--- a/a/avro-cpp/avro-cpp-1.11.1-GCC-12.2.0-Clang-15.0.5.eb
+++ b/a/avro-cpp/avro-cpp-1.11.1-GCC-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'avro-cpp'
+version = '1.11.1'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'https://avro.apache.org'
+description = """C++ implementation of Avro data serialization system."""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'extra_cxxflags': "-stdlib=libc++"}
+
+source_urls = ['https://github.com/apache/avro/archive/refs/tags/']
+sources = ['release-%(version)s.tar.gz']
+checksums = ['599f96bb405f72a35154b2477caa6254d723bb4e3f6a0e54e9ae540664321752']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+]
+dependencies = [
+    ('Boost', '1.78.0', versionsuffix),
+    ('Clang', '15.0.5'),
+]
+
+srcdir = "lang/c++"
+
+configopts = " -DCMAKE_CXX_COMPILER=clang++"
+generator = "Unix Makefiles"
+separate_build_dir = True
+
+postinstallcmds = [
+    "mkdir -p %(installdir)s/include/impl/json ",
+    "cp %(builddir)s/avro-release-%(version)s/lang/c++/impl/json/JsonDom.hh %(installdir)s/include/impl/json ",
+]
+
+sanity_check_paths = {
+    'files': ["bin/avrogencpp"],
+    'dirs': ["lib"],
+}
+
+sanity_check_commands = ["avrogencpp -h"]
+
+modextrapaths = {'CPATH': ['include/avro', 'include/impl/json']}
+
+moduleclass = 'lib'

--- a/b/Boost/Boost-1.78.0-GCC-12.2.0-Clang-15.0.5.eb
+++ b/b/Boost/Boost-1.78.0-GCC-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,43 @@
+##
+# Authors::   Denis Kristak <thenis@inuits.eu>
+##
+name = 'Boost'
+version = '1.78.0'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'https://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+toolchainopts = {'pic': True, 'extra_cxxflags': "-stdlib=libc++"}
+
+source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source/']
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+patches = ['Boost-1.78.0_define-unaryfunction-unconditionally.patch']
+checksums = [
+    {'boost_1_78_0.tar.gz': '94ced8b72956591c4775ae2207a9763d3600b30d9d7446562c552f0a14a63be7'},
+    {'Boost-1.78.0_define-unaryfunction-unconditionally.patch':
+     '367c60af1f1953b825a596f4536e8955ebb5ad19f29991b6f80fed1ad7b6d930'},
+]
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.12'),
+    ('XZ', '5.2.7'),
+    ('zstd', '1.5.2'),
+    ('ICU', '72.1'),
+    ('Clang', '15.0.5'),
+]
+
+configopts = '--without-libraries=python,mpi'
+
+# disable MPI, build Boost libraries with tagged layout
+boost_mpi = False
+tagged_layout = True
+explicit_compiler_path = False
+
+toolset = 'clang'
+build_toolset = 'clang'
+#use_glibcxx11_abi
+
+moduleclass = 'devel'

--- a/b/Boost/Boost-1.78.0_define-unaryfunction-unconditionally.patch
+++ b/b/Boost/Boost-1.78.0_define-unaryfunction-unconditionally.patch
@@ -1,0 +1,27 @@
+# Fix problem with clang because std::unary_function and std::binary_function were
+# removed from C++17. See https://cgit.freebsd.org/ports/commit/?id=c035007f958a9fa3c45bb1441a63540be39018ed
+# Patched by steven.vandenbrande@kuleuven.be 
+diff -ruN boost_1_78_0.orig/boost/functional.hpp boost_1_78_0/boost/functional.hpp
+--- boost_1_78_0.orig/boost/functional.hpp	2021-12-02 07:47:32.000000000 +0100
++++ boost_1_78_0/boost/functional.hpp	2023-10-28 14:49:37.403436000 +0200
+@@ -21,7 +21,6 @@
+     namespace functional
+     {
+         namespace detail {
+-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+             // std::unary_function and std::binary_function were both removed
+             // in C++17.
+ 
+@@ -39,12 +38,6 @@
+                 typedef Arg2 second_argument_type;
+                 typedef Result result_type;
+             };
+-#else
+-            // Use the standard objects when we have them.
+-
+-            using std::unary_function;
+-            using std::binary_function;
+-#endif
+         }
+     }
+ 

--- a/c/Catch2/Catch2-2.13.8.eb
+++ b/c/Catch2/Catch2-2.13.8.eb
@@ -1,0 +1,33 @@
+easyblock = 'CMakeMake'
+
+name = 'Catch2'
+version = '2.13.8'
+
+homepage = 'https://github.com/catchorg/Catch2'
+description = """A modern, C++-native, header-only,
+ test framework for unit-tests, TDD and BDD
+ - using C++11, C++14, C++17 and later
+   (or C++03 on the Catch1.x branch)
+"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/catchorg/Catch2/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a']
+
+# using CMake built with GCCcore to avoid relying on the system compiler to build it
+builddependencies = [
+    ('GCCcore', '12.2.0'),  # required to a access CMake when using hierarchical module naming scheme
+    ('binutils', '2.39', '', ('GCCcore', '12.2.0')),  # to make CMake compiler health check pass on old systems
+    ('CMake', '3.24.3', '', ('GCCcore', '12.2.0')),
+]
+
+separate_build_dir = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs':  ['include/catch2', 'lib64/cmake'],
+}
+
+moduleclass = 'lib'

--- a/c/Clang/Clang-15.0.5-GCCcore-12.2.0.eb
+++ b/c/Clang/Clang-15.0.5-GCCcore-12.2.0.eb
@@ -1,0 +1,61 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2015 Dmitri Gribenko, Ward Poelmans
+# Authors:: Dmitri Gribenko <gribozavr@gmail.com>
+# Authors:: Ward Poelmans <wpoely86@gmail.com>
+# License:: GPLv2 or later, MIT, three-clause BSD.
+# $Id$
+##
+
+name = 'Clang'
+version = '15.0.5'
+
+homepage = 'https://clang.llvm.org/'
+description = """C, C++, Objective-C compiler, based on LLVM.  Does not
+ include C++ standard library -- use libstdc++ from GCC."""
+
+# Clang also depends on libstdc++ during runtime, but this dependency is
+# already specified as the toolchain.
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-%(version)s"]
+sources = [
+    'llvm-project-%(version)s.src.tar.xz',
+]
+checksums = ['9c4278a6b8884eb7f4ae7dfe3c8e5445019824885e47cfdf1392563c47316fd6']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('Perl', '5.36.0'),
+    ('elfutils', '0.189'),
+    # Including Python bindings would require this as a runtime dep
+    ('Python', '3.10.8'),
+]
+dependencies = [
+    # since Clang is a compiler, binutils is a runtime dependency too
+    ('binutils', '2.39'),
+    ('hwloc', '2.8.0'),
+    ('libxml2', '2.10.3'),
+    ('ncurses', '6.3'),
+    ('GMP', '6.2.1'),
+    ('Z3', '4.12.2'),
+]
+
+
+# enabling RTTI makes the flang compiler need to link to libc++ so instead of
+#   flang-new -flang-experimental-exec -fopenmp hello_openmp.f90
+# you would need
+#   flang-new -flang-experimental-exec -fopenmp hello_openmp.f90 -l c++
+enable_rtti = False
+
+assertions = True
+python_bindings = False
+skip_all_tests = True
+
+llvm_runtimes = ['libunwind', 'libcxx', 'libcxxabi']
+llvm_projects = ['polly', 'lld', 'lldb', 'clang-tools-extra', 'flang']
+
+modextrapaths = {'CPATH': 'include/%(arch)s-unknown-linux-gnu/c++/v1'}
+
+moduleclass = 'compiler'

--- a/c/cppzmq/cppzmq-4.8.1.eb
+++ b/c/cppzmq/cppzmq-4.8.1.eb
@@ -1,0 +1,30 @@
+# ll4strw Lorentz Institute
+easyblock = 'CMakeMake'
+
+name = 'cppzmq'
+version = '4.8.1'
+
+homepage = 'https://github.com/zeromq/cppzmq'
+description = "cppzmq is a C++ binding for libzmq."
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/zeromq/%(name)s/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af']
+
+builddependencies = [
+    ('GCCcore', '12.2.0'),  # required for hierarchical module naming scheme
+    ('binutils', '2.39', '', ('GCCcore', '12.2.0')),
+    ('CMake', '3.24.3', '', ('GCCcore', '12.2.0')),
+    ('ZeroMQ', '4.1.8', '', ('GCCcore', '12.2.0')),
+]
+
+separate_build_dir = True
+
+sanity_check_paths = {
+    'files': ['include/zmq.hpp'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/d/distro/distro-1.8.0-GCCcore-12.2.0.eb
+++ b/d/distro/distro-1.8.0-GCCcore-12.2.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'distro'
+version = '1.8.0'
+
+homepage = 'https://github.com/python-distro/distro/'
+description = """distro provides information about the OS distribution it runs on, such as a reliable machine-readable ID, or version information."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8']
+
+builddependencies = [('binutils', '2.39')]
+
+dependencies = [('Python', '3.10.8')]
+
+download_dep_fail = True
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/distro'],
+    'dirs': ['bin', 'lib'],
+}
+
+sanity_check_commands = ["distro"]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easyblocks/boost.py
+++ b/easyblocks/boost.py
@@ -1,0 +1,366 @@
+##
+# Copyright 2009-2023 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for Boost, implemented as an easyblock
+
+@author: Stijn De Weirdt (Ghent University)
+@author: Dries Verdegem (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Pieter De Baets (Ghent University)
+@author: Jens Timmerman (Ghent University)
+@author: Ward Poelmans (Ghent University)
+@author: Petar Forai (IMP/IMBA)
+@author: Luca Marsella (CSCS)
+@author: Guilherme Peretti-Pezzi (CSCS)
+@author: Joachim Hein (Lund University)
+@author: Michele Dolfi (ETH Zurich)
+@author: Simon Branford (University of Birmingham)
+"""
+from distutils.version import LooseVersion
+import fileinput
+import glob
+import os
+import re
+import sys
+
+import easybuild.tools.toolchain as toolchain
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import ERROR
+from easybuild.tools.filetools import apply_regex_substitutions, read_file, symlink, which, write_file
+from easybuild.tools.modules import get_software_root, get_software_version
+from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import AARCH64, POWER, UNKNOWN
+from easybuild.tools.systemtools import get_cpu_architecture, get_glibc_version, get_shared_lib_ext
+
+
+class EB_Boost(EasyBlock):
+    """Support for building Boost."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize Boost-specific variables."""
+        super(EB_Boost, self).__init__(*args, **kwargs)
+
+        self.pyvers = []
+
+        if LooseVersion(self.version) >= LooseVersion("1.71.0"):
+            self.bjamcmd = 'b2'
+        else:
+            self.bjamcmd = 'bjam'
+
+    @staticmethod
+    def extra_options():
+        """Add extra easyconfig parameters for Boost."""
+        extra_vars = {
+            'boost_mpi': [False, "Build mpi boost module", CUSTOM],
+            'boost_multi_thread': [None, "Build boost with multi-thread option (DEPRECATED)", CUSTOM],
+            'tagged_layout': [None, "Build with tagged layout on library names, default from version 1.69.0", CUSTOM],
+            'single_threaded': [None, "Also build single threaded libraries, requires tagged_layout, "
+                                      "default from version 1.69.0", CUSTOM],
+            'toolset': [None, "Toolset to use for Boost configuration ('--with-toolset' for bootstrap.sh)", CUSTOM],
+            'build_toolset': [None, "Toolset to use for Boost compilation "
+                                    "('toolset' for b2, default calculated from toolset)", CUSTOM],
+            'mpi_launcher': [None, "Launcher to use when running MPI regression tests", CUSTOM],
+            'only_python_bindings': [False, "Only install Boost.Python library providing Python bindings", CUSTOM],
+            'use_glibcxx11_abi': [None, "Use the GLIBCXX11 ABI", CUSTOM],
+            'explicit_compiler_path': [True, "Explicitely set the compiler path to avoid B2 checking some standard paths like /opt", CUSTOM],
+        }
+        return EasyBlock.extra_options(extra_vars)
+
+    def patch_step(self):
+        """Patch Boost source code before building."""
+        super(EB_Boost, self).patch_step()
+
+        # TIME_UTC is also defined in recent glibc versions, so we need to rename it for old Boost versions (<= 1.49)
+        glibc_version = get_glibc_version()
+        old_glibc = glibc_version is not UNKNOWN and LooseVersion(glibc_version) > LooseVersion("2.15")
+        if old_glibc and LooseVersion(self.version) <= LooseVersion("1.49.0"):
+            self.log.info("Patching because the glibc version is too new")
+            files_to_patch = ["boost/thread/xtime.hpp"] + glob.glob("libs/interprocess/test/*.hpp")
+            files_to_patch += glob.glob("libs/spirit/classic/test/*.cpp") + glob.glob("libs/spirit/classic/test/*.inl")
+            for patchfile in files_to_patch:
+                try:
+                    for line in fileinput.input("%s" % patchfile, inplace=1, backup='.orig'):
+                        line = re.sub(r"TIME_UTC", r"TIME_UTC_", line)
+                        sys.stdout.write(line)
+                except IOError as err:
+                    raise EasyBuildError("Failed to patch %s: %s", patchfile, err)
+
+    def prepare_step(self, *args, **kwargs):
+        """Prepare build environment."""
+
+        super(EB_Boost, self).prepare_step(*args, **kwargs)
+
+        # keep track of Python version(s) used during installation,
+        # so we can perform a complete sanity check
+        if get_software_root('Python'):
+            self.pyvers.append(get_software_version('Python'))
+
+    def configure_step(self):
+        """Configure Boost build using custom tools"""
+
+        # boost_multi_thread is deprecated
+        if self.cfg['boost_multi_thread'] is not None:
+            self.log.deprecated("boost_multi_thread has been replaced by tagged_layout. "
+                                "We build with tagged layout and both single and multi threading libraries "
+                                "from version 1.69.0.", '5.0')
+            self.cfg['tagged_layout'] = True
+
+        # mpi sanity check
+        if self.cfg['boost_mpi'] and not self.toolchain.options.get('usempi', None):
+            raise EasyBuildError("When enabling building boost_mpi, also enable the 'usempi' toolchain option.")
+
+        # generate config depending on compiler used
+        toolset = self.cfg['toolset']
+        if toolset is None:
+            if self.toolchain.comp_family() == toolchain.INTELCOMP:
+                toolset = 'intel-linux'
+            elif self.toolchain.comp_family() == toolchain.GCC:
+                toolset = 'gcc'
+            else:
+                raise EasyBuildError("Unknown compiler used, don't know what to specify to --with-toolset, aborting.")
+
+        cmd = "%s ./bootstrap.sh --with-toolset=%s --prefix=%s %s"
+        tup = (self.cfg['preconfigopts'], toolset, self.installdir, self.cfg['configopts'])
+        run_cmd(cmd % tup, log_all=True, simple=True)
+
+        # Use build_toolset if specified or the bootstrap toolset without the OS suffix
+        self.toolset = self.cfg['build_toolset'] or re.sub('-linux$', '', toolset)
+
+        user_config = []
+
+        # Explicitely set the compiler path to avoid B2 checking some standard paths like /opt
+        cxx = os.getenv('CXX')
+        if cxx and self.cfg['explicit_compiler_path']:
+            cxx = which(cxx, on_error=ERROR)
+            # Remove default toolset config which may lead to duplicate toolsets (e.g. for intel-linux)
+            apply_regex_substitutions('project-config.jam', [('using %s ;' % toolset, '')])
+            # Add our toolset config with no version and full path to compiler
+            user_config.append("using %s : : %s ;" % (self.toolset, cxx))
+
+        if self.cfg['boost_mpi']:
+
+            # configure the boost mpi module
+            # http://www.boost.org/doc/libs/1_47_0/doc/html/mpi/getting_started.html
+            # let Boost.Build know to look here for the config file
+
+            # Check if using a Cray toolchain and configure MPI accordingly
+            if self.toolchain.toolchain_family() == toolchain.CRAYPE:
+                if self.toolchain.PRGENV_MODULE_NAME_SUFFIX == 'gnu':
+                    craympichdir = os.getenv('CRAY_MPICH2_DIR')
+                    craygccversion = os.getenv('GCC_VERSION')
+                    # We configure the gcc toolchain below, so make sure the EC doesn't use another toolset
+                    if self.toolset != 'gcc':
+                        raise EasyBuildError("For the cray toolchain the 'gcc' toolset must be used.")
+                    # Remove the previous "using gcc" line add above (via self.toolset) if present
+                    user_config = [x for x in user_config if not x.startswith('using gcc :')]
+                    user_config.extend([
+                        'local CRAY_MPICH2_DIR =  %s ;' % craympichdir,
+                        'using gcc ',
+                        ': %s' % craygccversion,
+                        ': CC ',
+                        ': <compileflags>-I$(CRAY_MPICH2_DIR)/include ',
+                        r'  <linkflags>-L$(CRAY_MPICH2_DIR)/lib \ ',
+                        '; ',
+                        'using mpi ',
+                        ': CC ',
+                        ': <find-shared-library>mpich ',
+                        ': %s' % self.cfg['mpi_launcher'],
+                        ';',
+                        '',
+                    ])
+                else:
+                    raise EasyBuildError("Bailing out: only PrgEnv-gnu supported for now")
+            else:
+                user_config.append("using mpi : %s ;" % os.getenv("MPICXX"))
+
+        write_file('user-config.jam', '\n'.join(user_config), append=True)
+
+    def build_step(self):
+        """Build Boost with bjam tool."""
+
+        self.bjamoptions = " --prefix=%s --user-config=user-config.jam" % self.installdir
+        if 'toolset=' not in self.cfg['buildopts']:
+            self.bjamoptions += " toolset=" + self.toolset
+
+        cxxflags = os.getenv('CXXFLAGS')
+        # only disable -D_GLIBCXX_USE_CXX11_ABI if use_glibcxx11_abi was explicitly set to False
+        # None value is the default, which corresponds to default setting (=1 since GCC 5.x)
+        if self.cfg['use_glibcxx11_abi'] is not None:
+            cxxflags += ' -D_GLIBCXX_USE_CXX11_ABI='
+            if self.cfg['use_glibcxx11_abi']:
+                cxxflags += '1'
+            else:
+                cxxflags += '0'
+        if cxxflags:
+            self.bjamoptions += " cxxflags='%s'" % cxxflags
+        ldflags = os.getenv('LDFLAGS')
+        if ldflags:
+            self.bjamoptions += " linkflags='%s'" % ldflags
+
+        # specify path for bzip2/zlib if module is loaded
+        for lib in ["bzip2", "zlib"]:
+            libroot = get_software_root(lib)
+            if libroot:
+                self.bjamoptions += " -s%s_INCLUDE=%s/include" % (lib.upper(), libroot)
+                self.bjamoptions += " -s%s_LIBPATH=%s/lib" % (lib.upper(), libroot)
+
+        if self.cfg['parallel']:
+            self.paracmd = "-j %s" % self.cfg['parallel']
+        else:
+            self.paracmd = ''
+
+        # Add list of default library settings from project-config (created by configure step)
+        # Required because any --with-* or --without-* overwrites this entirely
+        project_config = read_file('project-config.jam')
+        libraries = re.search(r'libraries = (.*) ;', project_config)
+        if libraries:
+            self.bjamoptions += libraries.group(1)
+
+        if self.cfg['only_python_bindings']:
+            # magic incantation to only install Boost Python bindings is... --with-python
+            # see http://boostorg.github.io/python/doc/html/building/installing_boost_python_on_your_.html
+            self.bjamoptions += " --with-python"
+
+        if LooseVersion(self.version) >= LooseVersion("1.69.0"):
+            # As of 1.69.0 we build with layout tagged and both single and multi threading
+            # Linking default libraries to multi-threaded versions.
+            if self.cfg['tagged_layout'] is None:
+                self.cfg['tagged_layout'] = True
+            if self.cfg['single_threaded'] is None:
+                self.cfg['single_threaded'] = True
+
+        # Default threading since at least 1.47.0 is multi with system layout
+
+        if self.cfg['tagged_layout']:
+            layout = "tagged"
+        else:
+            layout = "system"
+
+        if self.cfg['single_threaded']:
+            if not self.cfg['tagged_layout']:
+                raise EasyBuildError("Singled threaded build requires tagged layout.")
+            threading = "single,multi"
+        else:
+            threading = "multi"
+
+        self.bjamoptions += " threading=" + threading + " --layout=" + layout
+
+        if not self.cfg['boost_mpi'] and not self.cfg['only_python_bindings']:
+            # Default but avoids a warning. Building Boost.MPI is actually enabled by `using mpi` in the user-config
+            # Note: Can't use both --with-* and --without-*
+            self.bjamoptions += " --without-mpi"
+
+        self.log.info("Building Boost libraries")
+        # build with specified options
+        cmd = ' '.join([
+            self.cfg['prebuildopts'],
+            os.path.join('.', self.bjamcmd),
+            self.bjamoptions,
+            self.paracmd,
+            self.cfg['buildopts'],
+        ])
+        run_cmd(cmd, log_all=True, simple=True)
+
+    def install_step(self):
+        """Install Boost by copying files to install dir."""
+
+        # install boost libraries
+        self.log.info("Installing Boost libraries")
+
+        cmd = ' '.join([
+            self.cfg['preinstallopts'],
+            os.path.join('.', self.bjamcmd),
+            self.bjamoptions,
+            'install',
+            self.paracmd,
+            self.cfg['installopts'],
+        ])
+        run_cmd(cmd, log_all=True, simple=True)
+
+        if self.cfg['tagged_layout']:
+            if LooseVersion(self.version) >= LooseVersion("1.69.0") or not self.cfg['single_threaded']:
+                # Link tagged multi threaded libs as the default libs
+                lib_glob = 'lib*-mt*.*'
+                mt_replace = re.compile(r'-[^.]*\.')
+                for source_lib in glob.glob(os.path.join(self.installdir, 'lib', lib_glob)):
+                    target_lib = mt_replace.sub('.', os.path.basename(source_lib))
+                    symlink(os.path.basename(source_lib), os.path.join(self.installdir, 'lib', target_lib),
+                            use_abspath_source=False)
+
+    def sanity_check_step(self):
+        """Custom sanity check for Boost."""
+        shlib_ext = get_shared_lib_ext()
+
+        custom_paths = {
+            'files': [],
+            'dirs': ['include/boost']
+        }
+        if self.cfg['tagged_layout']:
+            lib_mt_suffix = '-mt'
+            # Architecture tags introduced in 1.69.0
+            if LooseVersion(self.version) >= LooseVersion("1.69.0"):
+                if get_cpu_architecture() == AARCH64:
+                    lib_mt_suffix += '-a64'
+                elif get_cpu_architecture() == POWER:
+                    lib_mt_suffix += '-p64'
+                else:
+                    lib_mt_suffix += '-x64'
+
+        if self.cfg['only_python_bindings']:
+            for pyver in self.pyvers:
+                pymajorver, pyminorver = pyver.split('.')[:2]
+                if LooseVersion(self.version) >= LooseVersion("1.67.0"):
+                    suffix = '%s%s' % (pymajorver, pyminorver)
+                elif int(pymajorver) >= 3:
+                    suffix = pymajorver
+                else:
+                    suffix = ''
+                custom_paths['files'].append(os.path.join('lib', 'libboost_python%s.%s' % (suffix, shlib_ext)))
+                if self.cfg['tagged_layout']:
+                    custom_paths['files'].append(
+                        os.path.join('lib', 'libboost_python%s%s.%s' % (suffix, lib_mt_suffix, shlib_ext)))
+
+        else:
+            custom_paths['files'].append(os.path.join('lib', 'libboost_system.%s' % shlib_ext))
+
+            if self.cfg['tagged_layout']:
+                custom_paths['files'].append(os.path.join('lib', 'libboost_system%s.%s' % (lib_mt_suffix, shlib_ext)))
+                custom_paths['files'].append(os.path.join('lib', 'libboost_thread%s.%s' % (lib_mt_suffix, shlib_ext)))
+
+            if self.cfg['boost_mpi']:
+                custom_paths['files'].append(os.path.join('lib', 'libboost_mpi.%s' % shlib_ext))
+                if self.cfg['tagged_layout']:
+                    custom_paths['files'].append(os.path.join('lib', 'libboost_mpi%s.%s' % (lib_mt_suffix, shlib_ext)))
+
+        super(EB_Boost, self).sanity_check_step(custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Set up a BOOST_ROOT environment variable to e.g. ease Boost handling by cmake"""
+        txt = super(EB_Boost, self).make_module_extra()
+        if not self.cfg['only_python_bindings']:
+            txt += self.module_generator.set_environment('BOOST_ROOT', self.installdir)
+        return txt

--- a/f/fmt/fmt-8.1.1-GCCcore-12.2.0-Clang-15.0.5.eb
+++ b/f/fmt/fmt-8.1.1-GCCcore-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'fmt'
+version = '8.1.1'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'http://fmtlib.net/'
+description = "fmt (formerly cppformat) is an open-source formatting library."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'pic': True, 'extra_cxxflags': "-stdlib=libc++"}
+
+source_urls = ['https://github.com/fmtlib/fmt/releases/download/%(version)s/']
+sources = ['fmt-%(version)s.zip']
+checksums = ['23778bad8edba12d76e4075da06db591f3b0e3c6c04928ced4a7282ca3400e5d']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('binutils', '2.39'),
+    ('Clang', '15.0.5'),
+]
+
+configopts  = " -DCMAKE_CXX_COMPILER=clang++"
+configopts += " -DBUILD_SHARED_LIBS=TRUE"
+configopts += " -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE"
+
+sanity_check_paths = {
+    'files': ['lib/libfmt.so'],
+    'dirs': ['include/fmt', 'lib/cmake'],
+}
+
+moduleclass = 'lib'

--- a/i/iCommands/iCommands-4.3.1-GCC-12.2.0-Clang-15.0.5.eb
+++ b/i/iCommands/iCommands-4.3.1-GCC-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'iCommands'
+version = '4.3.1'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'https://github.com/irods/irods_client_icommands'
+description = """iCommands, the default command line interface to iRODS."""
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/irods/irods_client_icommands/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+checksums = ['4cd07232dd0a633c26cfc4536b4ea48d29c445aeb80ef0420bc6786870f63e6c']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+]
+dependencies = [
+    ('iRODS', version, versionsuffix),
+]
+
+configopts  = " -DIRODS_DIR=${EBROOTIRODS}"
+configopts += " -DIRODS_BUILD_WITH_WERROR=no"
+configopts += " -DCPACK_GENERATOR=RPM"
+
+sanity_check_paths = {
+    'files': ["bin/icp"],
+    'dirs': ["bin", "var"],
+}
+
+moduleclass = 'tools'

--- a/i/iRODS/iRODS-4.3.1-GCC-12.2.0-Clang-15.0.5.eb
+++ b/i/iRODS/iRODS-4.3.1-GCC-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,76 @@
+easyblock = 'CMakeMake'
+
+name = 'iRODS'
+version = '4.3.1'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'https://github.com/irods/irods'
+description = "The Integrated Rule-Oriented Data System (iRODS) is open source data management software used by research, commercial, and governmental organizations worldwide."
+
+toolchain = {'name': 'GCC', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive/refs/tags/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    'iRODS-4.3.1_qualify-forward.patch',
+    'iRODS-4.3.1_fix-ambiguous-log-server-calls.patch',
+]
+checksums = [
+    {'4.3.1.tar.gz': '757b2c90792a63551280fddc86cf14a9ca4a3b5b21b7291eef355dbac37a5736'},
+    {'iRODS-4.3.1_qualify-forward.patch': '0396c04d6a1e07279d98d14a7077ce742982c7ad6782296e2b1c461c330a8a76'},
+    {'iRODS-4.3.1_fix-ambiguous-log-server-calls.patch':
+     '30f9bd3d93ee723ba644fca975170db856f57b1a437d159af4a2aa61bc3b4151'},
+]
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('distro', '1.8.0'),
+]
+
+dependencies = [
+    ('Catch2', '2.13.8', '', SYSTEM),
+    ('cppzmq', '4.8.1', '', SYSTEM),
+    ('Clang', '15.0.5'),
+    ('Z3', '4.12.2'),
+    ('ZeroMQ', '4.1.8'),
+    ('nlohmann_json', '3.10.4'),
+    ('spdlog', '1.9.2'),
+    ('Python', '3.10.8'),
+    ('unixODBC', '2.3.12'),
+    ('avro-cpp', '1.11.1', versionsuffix),
+    ('Boost', '1.78.0', versionsuffix),
+    ('nanodbc', '2.14.0', versionsuffix),
+    ('fmt', '8.1.1', versionsuffix),
+]
+
+osdependencies = [('pam-devel', 'libpam0g-dev')]
+
+# iRODS will by default search for dependencies in /opt/irods-externals
+# It is necessary to explicitly specify the path to each dependency
+configopts  = " -DIRODS_EXTERNALS_FULLPATH_CLANG=${EBROOTCLANG}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${EBROOTCLANG}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_AVRO=${EBROOTAVROMINCPP}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_BOOST=${EBROOTBOOST}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_CATCH2=${EBROOTCATCH2}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_CPPZMQ=${EBROOTCPPZMQ}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_JSON=${EBROOTNLOHMANN_JSON}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_SPDLOG=${EBROOTSPDLOG}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_ARCHIVE=${EBROOTLIBARCHIVE}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_FMT=${EBROOTFMT}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_NANODBC=${EBROOTNANODBC}"
+configopts += " -DIRODS_EXTERNALS_FULLPATH_ZMQ=${EBROOTZEROMQ}"
+# It is not clear why iRODS can't pickup the pam library, even whenit is in a
+# standard location.
+configopts += " -DPAM_LIBRARY=/usr/lib64/libpam.so.0"
+# A few flags to keep clang happy
+configopts += ' -DCMAKE_CXX_FLAGS="-Wno-deprecated-builtins -Wno-deprecated-declarations"'
+# iRODS does not define a package type for rhel, so in that case it is
+# necessary to specify CPACK_GENERATOR explicitly
+configopts += " -DCPACK_GENERATOR=RPM"
+
+sanity_check_paths = {
+    'files': ['lib/libirods_client.so'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'

--- a/i/iRODS/iRODS-4.3.1_fix-ambiguous-log-server-calls.patch
+++ b/i/iRODS/iRODS-4.3.1_fix-ambiguous-log-server-calls.patch
@@ -1,0 +1,20 @@
+# Clang cannot choose between two candidate functions for log_server::debug
+# that are defined in lib/core/src/irods_server_properties.cpp. By casting the
+# first argument to std::string_view, the ambiguity is resolved.
+# Patched by steven.vandenbrande@kuleuven.be
+diff --git a/lib/core/src/irods_server_properties.cpp b/lib/core/src/irods_server_properties.cpp
+index 9dedfe446..b47951f32 100644
+--- a/lib/core/src/irods_server_properties.cpp
++++ b/lib/core/src/irods_server_properties.cpp
+@@ -291,9 +291,9 @@ namespace irods
+             }
+         }
+ 
+-        log_server::debug("Before patch ==> {}", [this] { return std::make_tuple(config_props_.dump()); });
++        log_server::debug(std::string_view("Before patch ==> {}"), [this] { return std::make_tuple(config_props_.dump()); });
+         config_props_ = config_props_.patch(patch);
+-        log_server::debug("After patch ==> {}", [this] { return std::make_tuple(config_props_.dump()); });
++        log_server::debug(std::string_view("After patch ==> {}"), [this] { return std::make_tuple(config_props_.dump()); });
+ 
+         return patch;
+     } // reload

--- a/i/iRODS/iRODS-4.3.1_qualify-forward.patch
+++ b/i/iRODS/iRODS-4.3.1_qualify-forward.patch
@@ -1,0 +1,109 @@
+# Use std::forward instead of forward
+# Patched by steven.vandenbrande@kuleuven.be
+diff --git a/lib/core/include/irods/apiHandler.hpp b/lib/core/include/irods/apiHandler.hpp
+index b179f6d26..b29761f75 100644
+--- a/lib/core/include/irods/apiHandler.hpp
++++ b/lib/core/include/irods/apiHandler.hpp
+@@ -189,7 +189,7 @@ namespace irods
+                                                                         ctx,
+                                                                         operation_name,
+                                                                         "finally",
+-                                                                        forward<types_t>(_t)...);
++                                                                        std::forward<types_t>(_t)...);
+ 
+                     if (!finally_err.ok()) {
+                         irods::log(PASS(finally_err));
+@@ -225,7 +225,7 @@ namespace irods
+ 
+                     using adapted_func_type = std::function<error(irods::plugin_context&, rsComm_t*, types_t...)>;
+                     adapted_func_type adapted_fcn{api_call_adaptor<types_t...>(fcn)};
+-                    op_err = adapted_fcn(ctx, _comm, forward<types_t>(_t)...);
++                    op_err = adapted_fcn(ctx, _comm, std::forward<types_t>(_t)...);
+ 
+                     if (!op_err.ok() && !is_acceptable_error(op_err.code())) {
+                         // if the operation fails, invoke the exception pep
+@@ -234,7 +234,7 @@ namespace irods
+                                                ctx,
+                                                operation_name,
+                                                "except",
+-                                               forward<types_t>(_t)...);
++                                               std::forward<types_t>(_t)...);
+ 
+                         if (!except_err.ok()) {
+                             irods::log(PASS(except_err));
+@@ -250,7 +250,7 @@ namespace irods
+                                      ctx,
+                                      operation_name,
+                                      "post",
+-                                     forward<types_t>(_t)...);
++                                     std::forward<types_t>(_t)...);
+ 
+                 if (!post_err.ok()) {
+                     // if the post-pep fails, invoke the exception pep
+@@ -259,7 +259,7 @@ namespace irods
+                                            ctx,
+                                            operation_name,
+                                            "except",
+-                                           forward<types_t>(_t)...);
++                                           std::forward<types_t>(_t)...);
+ 
+                     if (!except_err.ok()) {
+                         irods::log(PASS(except_err));
+diff --git a/lib/core/include/irods/irods_plugin_base.hpp b/lib/core/include/irods/irods_plugin_base.hpp
+index 98a033b2b..50713a0eb 100644
+--- a/lib/core/include/irods/irods_plugin_base.hpp
++++ b/lib/core/include/irods/irods_plugin_base.hpp
+@@ -195,7 +195,7 @@ namespace irods
+                                                                         &out_param,
+                                                                         _operation_name,
+                                                                         "finally",
+-                                                                        forward<types_t>(_t)...);
++                                                                        std::forward<types_t>(_t)...);
+ 
+                     if (!finally_err.ok()) {
+                         irods::log(PASS(finally_err));
+@@ -231,7 +231,7 @@ namespace irods
+                         return pre_err;
+                     }
+ 
+-                    to_return_op_err = adapted_fcn(ctx, &out_param, forward<types_t>(_t)...);
++                    to_return_op_err = adapted_fcn(ctx, &out_param, std::forward<types_t>(_t)...);
+ 
+                     if(!to_return_op_err.ok()) {
+                         // if the operation fails, invoke the exception pep
+@@ -243,7 +243,7 @@ namespace irods
+                                                &out_param,
+                                                _operation_name,
+                                                "except",
+-                                               forward<types_t>(_t)...);
++                                               std::forward<types_t>(_t)...);
+ 
+                         if(!except_err.ok()) {
+                             irods::log(PASS(except_err));
+@@ -260,7 +260,7 @@ namespace irods
+                                      &out_param,
+                                      _operation_name,
+                                      "post",
+-                                     forward<types_t>(_t)...);
++                                     std::forward<types_t>(_t)...);
+ 
+                 if(!post_err.ok()) {
+                     out_param = "error="+std::to_string(post_err.code()) + ";message="+post_err.result();
+@@ -272,7 +272,7 @@ namespace irods
+                                            &out_param,
+                                            _operation_name,
+                                            "except",
+-                                           forward<types_t>(_t)...);
++                                           std::forward<types_t>(_t)...);
+ 
+                     if(!except_err.ok()) {
+                         irods::log(PASS(except_err));
+@@ -283,7 +283,7 @@ namespace irods
+ 
+                 return to_return_op_err;
+ #else // ENABLE_RE
+-                return adapted_fcn( ctx, &out_param, forward<types_t>(_t)... );
++                return adapted_fcn( ctx, &out_param, std::forward<types_t>(_t)... );
+ #endif // ENABLE_RE
+             }
+             catch (const boost::bad_any_cast&) {

--- a/l/libarchive/libarchive-3.5.2-GCCcore-12.2.0.eb
+++ b/l/libarchive/libarchive-3.5.2-GCCcore-12.2.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libarchive'
+version = '3.5.2'
+
+homepage = 'https://www.libarchive.org/'
+
+description = """
+ Multi-format archive and compression library
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://www.libarchive.org/downloads/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['5f245bd5176bc5f67428eb0aa497e09979264a153a074d35416521a5b8e86189']
+
+builddependencies = [
+    ('binutils', '2.39'),
+]
+
+dependencies = [
+    ('zlib', '1.2.12'),
+    ('XZ', '5.2.7'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+sanity_check_paths = {
+    'files': ['include/archive.h', 'lib/libarchive.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'share/man/man3'],
+}
+
+moduleclass = 'tools'

--- a/n/nanodbc/nanodbc-2.14.0-GCCcore-12.2.0-Clang-15.0.5.eb
+++ b/n/nanodbc/nanodbc-2.14.0-GCCcore-12.2.0-Clang-15.0.5.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'nanodbc'
+version = '2.14.0'
+versionsuffix = '-Clang-15.0.5'
+
+homepage = 'https://github.com/nanodbc/nanodbc'
+description = "A small C++ wrapper for the native C ODBC API."
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+toolchainopts = {'extra_cxxflags': "-stdlib=libc++"}
+
+source_urls = ['https://github.com/%(name)s/%(name)s/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['56228372042b689beccd96b0ac3476643ea85b3f57b3f23fb11ca4314e68b9a5']
+
+builddependencies = [
+    ('CMake', '3.24.3'),
+    ('unixODBC', '2.3.12'),
+    ('Clang', '15.0.5'),
+]
+
+configopts  = " -DCMAKE_CXX_COMPILER=clang++"
+configopts += " -DBUILD_SHARED_LIBS=TRUE"
+#configopts += ' -DCMAKE_CXX_FLAGS="-Wno-restrict"'
+
+sanity_check_paths = {
+    'files': ['lib/libnanodbc.%s' % SHLIB_EXT],
+    'dirs': ['lib/cmake', 'include/'],
+}
+
+moduleclass = 'lib'

--- a/n/nlohmann_json/nlohmann_json-3.10.4-GCCcore-12.2.0.eb
+++ b/n/nlohmann_json/nlohmann_json-3.10.4-GCCcore-12.2.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'CMakeMake'
+
+name = 'nlohmann_json'
+version = '3.10.4'
+
+homepage = 'https://github.com/nlohmann/json'
+description = """JSON for Modern C++"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/nlohmann/json/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['1155fd1a83049767360e9a120c43c578145db3204d2b309eba49fbbedd0f4ed3']
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('CMake', '3.24.3'),
+]
+
+sanity_check_paths = {
+    'files': ['include/nlohmann/json.hpp'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'

--- a/s/spdlog/spdlog-1.9.2-GCCcore-12.2.0.eb
+++ b/s/spdlog/spdlog-1.9.2-GCCcore-12.2.0.eb
@@ -1,0 +1,24 @@
+easyblock = 'CMakeMake'
+
+name = 'spdlog'
+version = '1.9.2'
+
+homepage = 'https://github.com/gabime/spdlog'
+description = 'Very fast, header-only/compiled, C++ logging library.'
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/gabime/spdlog/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38']
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('CMake', '3.24.3'),
+]
+
+sanity_check_paths = {
+    'files': ['include/spdlog/spdlog.h'],
+    'dirs': ['lib64/cmake', 'lib64/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/u/unixODBC/unixODBC-2.3.12-GCCcore-12.2.0.eb
+++ b/u/unixODBC/unixODBC-2.3.12-GCCcore-12.2.0.eb
@@ -1,0 +1,16 @@
+easyblock = 'ConfigureMake'
+
+name = 'unixODBC'
+version = '2.3.12'
+
+homepage = "https://www.unixodbc.org"
+description = """unixODBC provides a uniform interface between
+application and database driver"""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['ftp://ftp.unixodbc.org/pub/unixODBC']
+sources = [SOURCE_TAR_GZ]
+checksums = ['f210501445ce21bf607ba51ef8c125e10e22dffdffec377646462df5f01915ec']
+
+moduleclass = 'data'

--- a/z/ZeroMQ/ZeroMQ-4.1.8-GCCcore-12.2.0.eb
+++ b/z/ZeroMQ/ZeroMQ-4.1.8-GCCcore-12.2.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'ZeroMQ'
+version = '4.1.8'
+
+homepage = 'https://www.zeromq.org/'
+description = """ZeroMQ looks like an embeddable networking library but acts like a concurrency framework.
+ It gives you sockets that carry atomic messages across various transports like in-process,
+ inter-process, TCP, and multicast. You can connect sockets N-to-N with patterns like fanout,
+ pub-sub, task distribution, and request-reply. It's fast enough to be the fabric for clustered
+ products. Its asynchronous I/O model gives you scalable multicore applications, built as asynchronous
+ message-processing tasks. It has a score of language APIs and runs on most operating systems."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.2.0'}
+
+source_urls = ['https://github.com/zeromq/zeromq4-1/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['eb36467aa6658428c588de8075a8ce422953bff3bb5e9aa0dc9f2a06d265bee5']
+
+builddependencies = [
+    ('binutils', '2.39'),
+    ('pkgconf', '1.9.3'),
+]
+
+dependencies = [
+    ('OpenPGM', '5.2.122'),
+    ('libsodium', '1.0.18'),
+    ('util-linux', '2.38.1'),
+]
+
+# Compialtion warnings in GCC 11, cf. https://github.com/zeromq/libzmq/issues/4178
+# Needto disable warnings as errors.
+configopts = '--with-pic --with-pgm --with-libsodium --disable-Werror'
+
+sanity_check_paths = {
+    'files': ['lib/libzmq.%s' % SHLIB_EXT, 'lib/libzmq.a'],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
My colleagues asked to provide an installation of iCommands that can be done with EasyBuild, to make it available on Hortense.
@boegel Can you review the provided easyconfigs and/or install them on Hortense? For now I requested merging into `site-kul`, but maybe the `vsc` branch is more appropriate if it is ready for Hortense?


Notes:
* The ftp download of unixODBC sources fails on Hortense, after a manual download it is ok
* Some dependencies might be only required during the build