### PR TITLE
Add dependencies for LISF with intel-2023b

### DIFF
--- a/e/ESMF/ESMF-8.6.1-intel-2023b.eb
+++ b/e/ESMF/ESMF-8.6.1-intel-2023b.eb
@@ -1,0 +1,37 @@
+name = 'ESMF'
+version = '8.6.1'
+
+homepage = 'https://www.earthsystemcog.org/projects/esmf/'
+description = """The Earth System Modeling Framework (ESMF) is a suite of software tools for developing
+ high-performance, multi-component Earth science modeling applications."""
+
+toolchain = {'name': 'intel', 'version': '2023b'}
+toolchainopts = {'usempi': True, 'openmp': True, 'cstd': 'c++11', 'pic': True}
+
+source_urls = ['https://github.com/esmf-org/esmf/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['ESMF-6.1.1_libopts.patch']
+checksums = [
+    {'v8.6.1.tar.gz': 'dc270dcba1c0b317f5c9c6a32ab334cb79468dda283d1e395d98ed2a22866364'},
+    {'ESMF-6.1.1_libopts.patch': '3851627f07c32a7da55d99072d619942bd3a1d9dd002e1557716158e7aacdaf4'},
+]
+
+builddependencies = [('CMake', '3.27.6')]
+
+dependencies = [
+    ('netCDF', '4.9.2'),
+    ('netCDF-Fortran', '4.6.1'),
+    ('netCDF-C++4', '4.3.1'),
+    ('libarchive', '3.7.2'),
+]
+
+# disable errors from GCC 10 on mismatches between actual and dummy argument lists (GCC 9 behaviour)
+prebuildopts = 'ESMF_F90COMPILEOPTS="${ESMF_F90COMPILEOPTS} -fallow-argument-mismatch"'
+
+buildopts = 'ESMF_NETCDF_INCLUDE=$EBROOTNETCDFMINFORTRAN/include '
+buildopts += 'ESMF_NETCDF_LIBS="`nc-config --libs` `nf-config --flibs` `ncxx4-config --libs`"'
+
+# too parallel causes the build to become really slow
+maxparallel = 8
+
+moduleclass = 'geo'

--- a/e/ecCodes/ecCodes-2.31.0-iimpi-2023b.eb
+++ b/e/ecCodes/ecCodes-2.31.0-iimpi-2023b.eb
@@ -1,0 +1,46 @@
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.31.0'
+
+homepage = 'https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home'
+description = """ecCodes is a package developed by ECMWF which provides an application programming interface and
+ a set of tools for decoding and encoding messages in the following formats: WMO FM-92 GRIB edition 1 and edition 2,
+ WMO FM-94 BUFR edition 3 and edition 4, WMO GTS abbreviated header (only decoding)."""
+
+toolchain = {'name': 'iimpi', 'version': '2023b'}
+toolchainopts = {'usempi': False}
+
+source_urls = ['https://github.com/ecmwf/eccodes/archive/refs/tags/']
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': '%(namelower)s-%(version)s.tar.gz'}]
+checksums = ['cb4cd3bab9cebd85a00397e12ce8e4a579b2f0a25aaf6df763436cf37db063e1']
+
+builddependencies = [
+    ('CMake', '3.27.6'),
+    ('ecBuild', '3.8.0', '', SYSTEM),
+]
+dependencies = [
+    ('netCDF', '4.9.2'),
+    ('JasPer', '4.0.0'),
+    ('libjpeg-turbo', '3.0.1'),
+    ('libpng', '1.6.40'),
+    ('zlib', '1.2.13'),
+    ('libaec', '1.0.6'),
+]
+
+# Python bindings are provided by a separate package 'eccodes-python'
+configopts = "-DENABLE_NETCDF=ON -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_JPG=ON "
+configopts += "-DENABLE_JPG_LIBJASPER=ON -DENABLE_ECCODES_THREADS=ON"
+
+
+sanity_check_paths = {
+    'files': ['bin/bufr_compare', 'bin/bufr_copy', 'bin/bufr_dump', 'bin/bufr_filter', 'bin/bufr_get', 'bin/bufr_ls',
+              'bin/grib_compare', 'bin/grib_copy', 'bin/grib_dump', 'bin/grib_filter', 'bin/grib_get', 'bin/grib_ls',
+              'bin/gts_compare', 'bin/gts_copy', 'bin/gts_dump', 'bin/gts_filter', 'bin/gts_get', 'bin/gts_ls',
+              'bin/metar_compare', 'bin/metar_copy', 'bin/metar_dump', 'bin/metar_filter', 'bin/metar_get',
+              'bin/metar_ls', 'bin/codes_count', 'bin/codes_info', 'bin/codes_split_file',
+              'lib/libeccodes_f90.%s' % SHLIB_EXT, 'lib/libeccodes.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'tools'

--- a/h/HDF-EOS2/HDF-EOS2-3.0-GCCcore-13.2.0.eb
+++ b/h/HDF-EOS2/HDF-EOS2-3.0-GCCcore-13.2.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'HDF-EOS2'
+version = '3.0'
+
+homepage = 'https://hdfeos.org/'
+description = """HDF-EOS libraries are software libraries built on HDF libraries.
+ It supports three data structures for remote sensing data: Grid, Point and Swath."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://git.earthdata.nasa.gov/projects/DAS/repos/hdfeos/raw/']
+sources = [
+    {'download_filename': '%(namelower)s-%(version)s-src.tar.gz?at=3128a738021501c821549955f6c78348e5f33850',
+     'filename': SOURCE_TAR_GZ}
+]
+checksums = ['3a5564b4d69b541139ff7dfdad948696cf31d9d1a6ea8af290c91a4c0ee37188']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('HDF', '4.2.16-2'),
+    ('Szip', '2.1.1'),
+]
+
+preconfigopts = 'export CC="$EBROOTHDF/bin/h4cc -Df2cFortran" && '
+
+# `--enable-install-include`` mentioned at https://hdfeos.org/software/hdfeos.php
+# but not available, likely the default and the option removed. Recheck in next release!
+configopts = "--with-szlib=$EBROOTSZIP "
+
+sanity_check_paths = {
+    'files': ['include/HdfEosDef.h', 'lib/libGctp.a', 'lib/libhdfeos.a'],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'data'

--- a/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0-w-fortran-no-netCDF.eb
+++ b/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0-w-fortran-no-netCDF.eb
@@ -47,7 +47,7 @@ configopts = [
 
 
 sanity_check_paths = {
-    'files': ['bin/h4cc', 'bin/ncdump', 'lib/libdf.a', 'lib/libhdf4.settings', 'lib/libmfhdf.a', 'lib/libmfhdf.a'],
+    'files': ['bin/h4cc', 'bin/ncdump', 'lib/libdf.a', 'lib/libhdf4.settings', 'lib/libmfhdf.a'],
     'dirs': ['include/%(namelower)s'],
 }
 

--- a/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0-w-fortran-no-netCDF.eb
+++ b/h/HDF/HDF-4.2.16-2-GCCcore-13.2.0-w-fortran-no-netCDF.eb
@@ -1,0 +1,61 @@
+easyblock = 'ConfigureMake'
+
+name = 'HDF'
+version = '4.2.16-2'
+versionsuffix='-w-fortran-no-netCDF'
+
+homepage = 'https://support.hdfgroup.org/products/hdf4/'
+description = """
+ HDF (also known as HDF4) is a library and multi-object file format for
+ storing and managing data between machines.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://support.hdfgroup.org/ftp/%(name)s/releases/%(name)s%(version)s/src/']
+sources = [SOURCELOWER_TAR_GZ]
+
+checksums = [
+    'a24b18312d421686031c2d66635f7d5abb2fe879f8a182b7e02797b0da8d1f6c',  # %(namelower)s-%(version)s.tar.gz
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+]
+dependencies = [
+    ('libjpeg-turbo', '3.0.1'),
+    ('Szip', '2.1.1'),
+    ('zlib', '1.2.13'),
+    ('libtirpc', '1.3.4'),
+]
+
+preconfigopts = "LIBS='-ltirpc' "
+
+local_common_configopts = '--with-szlib=$EBROOTSZIP CFLAGS="$CFLAGS -I$EBROOTLIBTIRPC/include/tirpc" '
+local_common_configopts += '--includedir=%(installdir)s/include/%(namelower)s '
+
+configopts = [
+    local_common_configopts,
+    # Cannot build shared libraries and Fortran...
+    # https://trac.osgeo.org/gdal/wiki/HDF#IncompatibilitywithNetCDFLibraries
+    # netcdf must be disabled to allow HDF to be used by GDAL
+    local_common_configopts + "--disable-netcdf --enable-fortran",
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/h4cc', 'bin/ncdump', 'lib/libdf.a', 'lib/libhdf4.settings', 'lib/libmfhdf.a', 'lib/libmfhdf.a'],
+    'dirs': ['include/%(namelower)s'],
+}
+
+sanity_check_commands = [
+    "h4cc --help",
+    "ncdump -V",
+]
+
+modextrapaths = {'CPATH': 'include/%(namelower)s'}
+
+moduleclass = 'data'


### PR DESCRIPTION
@w-lampaert Samuel asked to install the dependencies for LISF with intel-2023b (and optionally foss-2023b) on Hortense, so we need to provide the easyconfigs. I think the following are sufficient:
- `ESMF-8.6.1-intel-2023b.eb`: trivial toolchain adaptation from `ESMF-8.6.1-foss-2023b.eb`
- `ecCodes-2.31.0-iimpi-2023b.eb`: trivial toolchain adaptation from `ecCodes-2.31.0-gompi-2023b.eb`
- `HDF-4.2.16-2-GCCcore-13.2.0-w-fortran-no-netCDF`: version without shared libraries, without netCDF, with Fortran

Are any additional easyconfigs required to install the dependencies with foss-2023b?