### PR TITLE
Fix problems for PsN-5.3.0-foss-2021a.eb

### DIFF
--- a/p/PsN/PsN-5.3.0-foss-2021a.eb
+++ b/p/PsN/PsN-5.3.0-foss-2021a.eb
@@ -79,7 +79,7 @@ exts_list = [
         'checksums': ['9a030b44ff6841e219431ddcb0d6483bb659d6ec32cbb8f9fe756e13cddfd312'],
         # Installing from the extension's directory leads to R CMD INSTALL to use renv
         # which then fails because it is not finding packages included in the R installation
-        'preinstallopts': 'mkdir build && cd build &&',
+        'preinstallopts': 'mkdir -p build && cd build &&',
     }),
     ('Math::Random', '0.72', {
         'source_tmpl': 'Math-Random-%(version)s.tar.gz',

--- a/p/PsN/psn.py
+++ b/p/PsN/psn.py
@@ -45,7 +45,7 @@ class PsN(PerlModule):
             'Press ENTER to exit the installation program.': '',
         }
 
-        maxhits = 200  # to give enough time to pharmpy installation
+        maxhits = 2000  # to give enough time to pharmpy installation
 
         run_cmd_qa(cmd, qanda, maxhits=maxhits, log_all=True, simple=True)
 


### PR DESCRIPTION
When installing with EasyBuild 5.0.0, it was necessary 
- to use `mkdir -p build` instead of `mkdir build`, apparently the `build` directory is already created before
- to increase `maxhits`, not sure why