### PR TITLE
PsN: librsvg dependency and larger maxhits

### DIFF
--- a/p/PsN/PsN-5.5.0-foss-2024a.eb
+++ b/p/PsN/PsN-5.5.0-foss-2024a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('R-bundle-CRAN', '2024.11'),
     ('GMP', '6.3.0'),
     ('MPFR', '4.2.1'),
+    ('librsvg', '2.60.0'),
 ]
 
 exts_defaultclass = 'RPackage'

--- a/p/PsN/psn.py
+++ b/p/PsN/psn.py
@@ -45,7 +45,7 @@ class PsN(PerlModule):
             'Press ENTER to exit the installation program.': '',
         }
 
-        maxhits = 2000  # to give enough time to pharmpy installation
+        maxhits = 4000  # to give enough time to pharmpy installation
 
         run_cmd_qa(cmd, qanda, maxhits=maxhits, log_all=True, simple=True)
 


### PR DESCRIPTION
I was looking into why our recent PsN builds were failing and it looks like the PsN installer just needs a bit more time. In the process I also saw that in the `5.5.0` version the installer did not succeed in installing some R packages because of a missing `librsvg` dependency.