### PR TITLE
Add easyconfigs for PredSim dependencies

### DIFF
--- a/a/ADOL-C/ADOL-C-2.7.2-gompi-2024a.eb
+++ b/a/ADOL-C/ADOL-C-2.7.2-gompi-2024a.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'ADOL-C'
+version = '2.7.2'
+
+homepage = 'https://projects.coin-or.org/ADOL-C'
+
+description = """The package ADOL-C (Automatic Differentiation by OverLoading in C++) facilitates
+the evaluation of first and higher derivatives of vector functions that are defined
+by computer programs written in C or C++. The resulting derivative evaluation
+routines may be called from C/C++, Fortran, or any other language that can be linked
+with C. 
+"""
+
+toolchain = {'name': 'gompi', 'version': '2024a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/coin-or/%(name)s/archive/releases']
+sources = ['%(version)s.tar.gz']
+checksums = ['701e0856baae91b98397960d5e0a87a549988de9d4002d0e9a56fa08f5455f6e']
+
+builddependencies = [('Autotools', '20231222')]
+
+preconfigopts = 'autoreconf -fi && '
+configopts = '--enable-sparse'
+
+sanity_check_paths = {
+    'files': ['lib64/libadolc.so'],
+    'dirs': ['include/adolc'],
+}
+
+moduleclass = 'system'

--- a/b/BTKcore/BTKcore-20180508-foss-2024a.eb
+++ b/b/BTKcore/BTKcore-20180508-foss-2024a.eb
@@ -1,0 +1,39 @@
+easyblock = 'CMakeMake'
+
+name = 'BTKcore'
+version = '20180508'
+local_commit = '6d787d0be223851a8f454f2ee8c7d9e47b84cbbe'
+
+homepage = 'https://github.com/opensim-org/BTKCore'
+description = """Core of the project Biomechanical-ToolKit (BTK) which represent biomechanical data, file formats and data processing"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/opensim-org/BTKCore/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': '%(name)s-%(version)s.zip'}]
+patches = ['BTKcore_use-cxx-11-standard.patch']
+checksums = [
+    {'BTKcore-20180508.zip': 'bb31f74b496b51ef1f55394d41265bd2d8e961e2c81dca731e5a5b9e0b85c35c'},
+    {'BTKcore_use-cxx-11-standard.patch': 'fa2541c6f2b7685663c15e141777d5b79b5692ee60c5bd0c43c8cb4f8c64b444'},
+]
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+]
+
+configopts = ' -G"Unix Makefiles" -DBUILD_SHARED_LIBS:BOOL=ON'
+
+sanity_check_paths = {
+    'files': ['lib/btk-0.4dev/libBTKCommon.%s' % SHLIB_EXT],
+    'dirs': ['include', 'lib'],
+}
+
+modextrapaths = {
+    'CPATH': 'include/btk-0.4dev',
+    'LD_LIBRARY_PATH': 'lib/btk-0.4dev',
+}
+
+moduleclass = 'tools'

--- a/b/BTKcore/BTKcore_use-cxx-11-standard.patch
+++ b/b/BTKcore/BTKcore_use-cxx-11-standard.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dd59d64c..ac6fd1bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,7 @@
+ CMAKE_MINIMUM_REQUIRED(VERSION 2.6.2)
+ # BTK: Biomechanical ToolKit
+ PROJECT(BTK)
++set (CMAKE_CXX_STANDARD 11)
+ 
+ # BTK version number.
+ SET(BTK_VERSION_MAJOR 0)

--- a/c/COINMUMPS/COINMUMPS-3.0.10-foss-2024a-metis.eb
+++ b/c/COINMUMPS/COINMUMPS-3.0.10-foss-2024a-metis.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'COINMUMPS'
+version = '3.0.10'
+versionsuffix = '-metis'
+
+homepage = 'https://github.com/coin-or-tools/ThirdParty-Mumps'
+description = "This is an autotools-based build system to build and install MUltifrontal Massively Parallel sparse direct Solver (MUMPS). This installation of MUMPS is used by some other COIN-OR projects."
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/coin-or-tools/ThirdParty-Mumps/archive/releases']
+sources = ['%(version)s.tar.gz']
+checksums = ['a93d19dac80dc1620fa7e3ca4621a5cb1e97c4d200aca7731f7ecc0b3548d514']
+
+dependencies = [
+    ('SCOTCH', '7.0.6'),
+    ('METIS', '5.1.0'),
+]
+
+maxparallel = 1
+
+# fix 'Type mismatch between actual argument' errors with GCC 10.x
+preconfigopts = './get.Mumps && export FCFLAGS="$FCFLAGS -fallow-argument-mismatch" && '
+configopts = '--with-lapack-lflags="-lscalapack -lflexiblas -lgfortran -lm"'
+
+sanity_check_paths = {
+    'files': ['lib/libcoinmumps.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'

--- a/c/CasADi-MATLAB/CasADi-MATLAB-20200618-foss-2024a.eb
+++ b/c/CasADi-MATLAB/CasADi-MATLAB-20200618-foss-2024a.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'CasADi-MATLAB'
+version = '20200618'
+local_commit = 'd074c221e22bd754f240f3597371418733e5efd4'
+
+homepage = 'https://web.casadi.org/'
+description = """CasADi is an open-source tool for nonlinear optimization and algorithmic differentiation."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/casadi/casadi/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': 'CasADi-%(version)s.zip'}]
+checksums = [
+    {'CasADi-20200618.zip': '44ed94d320a2d3cdd0c5dfa76e7647649ca1564875c7c157a8f9f949ef3961a8'},
+]
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('SWIG', '20180415', '-with-matlab'),
+]
+
+dependencies = [
+    ('Ipopt', '3.12.8'),
+    ('MATLAB', '2024b-r5', '', SYSTEM),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libcasadi.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+configopts = "-DWITH_IPOPT=ON -DWITH_MATLAB=ON -DWITH_THREAD=ON"
+
+moduleclass = 'tools'

--- a/c/CasADi/CasADi-3.7.0-gfbf-2024a.eb
+++ b/c/CasADi/CasADi-3.7.0-gfbf-2024a.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonBundle'
+
+name = 'CasADi'
+version = '3.7.0'
+
+homepage = 'https://web.casadi.org'
+description = """CasADi is an open-source tool for nonlinear optimization and algorithmic differentiation.
+It facilitates rapid — yet efficient — implementation of different methods for numerical optimal control,
+both in an offline context and for nonlinear model predictive control (NMPC)."""
+
+toolchain = {'name': 'gfbf', 'version': '2024a'}
+dependencies = [('Python', '3.12.3'),
+                ('SciPy-bundle', '2024.05'),
+                ('CMake', '3.29.3')]
+
+exts_list = [
+    ('casadi', version, {
+        'modulename': 'casadi',
+        'checksums': ['21254f17eb5551c4a938641cc1b815ff3da27271ab2c36e44a3e90ec50ba471f'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib', 'lib64'],
+}
+
+moduleclass = 'math'

--- a/c/CasADi/CasADi-3.7.0-gfbf-2024a.eb
+++ b/c/CasADi/CasADi-3.7.0-gfbf-2024a.eb
@@ -15,14 +15,8 @@ dependencies = [('Python', '3.12.3'),
 
 exts_list = [
     ('casadi', version, {
-        'modulename': 'casadi',
         'checksums': ['21254f17eb5551c4a938641cc1b815ff3da27271ab2c36e44a3e90ec50ba471f'],
     }),
 ]
-
-sanity_check_paths = {
-    'files': [],
-    'dirs': ['lib', 'lib64'],
-}
 
 moduleclass = 'math'

--- a/c/ColPack/ColPack-20180108-GCCcore-13.3.0.eb
+++ b/c/ColPack/ColPack-20180108-GCCcore-13.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'CMakeMake'
+
+name = 'ColPack'
+version = '20180108'
+local_commit = '72f691e91d59e8eb2123f258e67a4ddc72d105ee'
+
+homepage = 'https://cscapes.cs.purdue.edu/coloringpage/'
+description = """ColPack is a package comprising of implementations of algorithms for the specialized vertex coloring problems discussed in the previous section as well as algorithms for a variety of related supporting tasks in derivative computation."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/opensim-org/colpack/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': '%(name)s-%(version)s.zip'}]
+checksums = ['7f2d707e69cb02113e3bf83be47db7d4a36351ac474756e33d2a67a480617bbf']
+
+builddependencies = {
+    ('CMake', '3.29.3'),
+}
+
+dependencies = []
+
+sanity_check_paths = {
+    'files': ['lib/libColPack.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'math'

--- a/d/docopt.cpp/docopt.cpp-0.6.3-GCCcore-13.3.0.eb
+++ b/d/docopt.cpp/docopt.cpp-0.6.3-GCCcore-13.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'CMakeMake'
+
+name = 'docopt.cpp'
+version = '0.6.3'
+
+homepage = 'https://github.com/docopt/docopt.cpp'
+description = """docopt.cpp is a C++ port of docopt, which creates beautiful command-line interfaces"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/docopt/docopt.cpp/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['28af5a0c482c6d508d22b14d588a3b0bd9ff97135f99c2814a5aa3cbff1d6632']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+]
+
+sanity_check_paths = {
+    'files': ['lib/libdocopt.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}

--- a/e/EZC3D/EZC3D-1.4.3-foss-2024a.eb
+++ b/e/EZC3D/EZC3D-1.4.3-foss-2024a.eb
@@ -1,0 +1,40 @@
+easyblock = "CMakePythonPackage"
+
+name = 'EZC3D'
+version = '1.4.3'
+
+homepage = 'https://pyomeca.github.io/Documentation/ezc3d/index.html'
+description = """EZC3D is an easy to use reader, modifier and writer for C3D format files. It is
+written en C++ with proper binders for Python and MATLAB/Octave scripting
+languages."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+github_account = 'pyomeca'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['Release_%(version)s.tar.gz']
+checksums = ['cec06a730eca0c239a64e9afaac6246813e8602ba02f32975ed8e1ce58977ec7']
+
+builddependencies = {
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+#    ('SWIG', '4.2.1'),
+    ('SWIG', '20180415', '-with-matlab'),
+}
+
+dependencies = {
+    ('Python', '3.12.3'),
+    ('SciPy-bundle', '2024.05'),
+}
+
+# enable Python bindings
+_py_install_dir = "%(installdir)s/lib/python%(pyshortver)s/site-packages/%(namelower)s"
+configopts = "-DBINDER_PYTHON3=ON "
+configopts += "-DPYTHON_INSTALL_PREFIX=%s" % _py_install_dir
+
+sanity_check_paths = {
+    'files': ['lib/ezc3d/libezc3d.%s' % SHLIB_EXT],
+    'dirs': ['include/ezc3d', _py_install_dir],
+}
+
+moduleclass = 'lib'

--- a/i/Ipopt/Ipopt-3.12.8-foss-2024a.eb
+++ b/i/Ipopt/Ipopt-3.12.8-foss-2024a.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'Ipopt'
+version = '3.12.8'
+
+homepage = 'https://projects.coin-or.org/Ipopt'
+description = """IPOPT (Interior Point Optimizer, pronounced Eye-Pea-Opt)
+is an open source software package for large-scale nonlinear optimization. 
+This installation also includes the coinhsl package."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/coin-or/Ipopt/archive/refs/tags/releases']
+sources = ['%(version)s.tar.gz']
+checksums = ['fa120112cd3722927f4c9ab3fb7eff9a25638ea28d467874854779a81c7cdde8']
+
+dependencies = [
+    ('COINMUMPS', '3.0.10', '-metis'),
+]
+
+configopts = '--with-mumps --with-mumps-cflags="-I$EBROOTCOINMUMPS/include" --with-mumps-lflags="-ldmumps -lmetis"'
+configopts += ' --with-lapack="$LIBLAPACK"'
+configopts += ' --with-blas-lib="-L${EBROOTOPENBLAS}/lib" --with-blas-inc="-I${EBROOTOPENBLAS}/inc"'
+
+sanity_check_paths = {
+    'files': ['lib/libipopt.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'math'

--- a/m/MATLAB/MATLAB-2024b-r5.eb
+++ b/m/MATLAB/MATLAB-2024b-r5.eb
@@ -1,0 +1,33 @@
+name = 'MATLAB'
+version = '2024b'
+_update = '5'
+versionsuffix = '-r%s' % _update
+
+homepage = 'https://www.mathworks.com/products/matlab'
+description = """MATLAB is a high-level language and interactive environment
+ that enables you to perform computationally intensive tasks faster than with
+ traditional programming languages such as C, C++, and Fortran."""
+
+toolchain = SYSTEM
+
+sources = ['%s%s/R%s_Update_%s_Linux.iso' % \
+           (version, versionsuffix, version, _update)]
+checksums = ['93b0f38fa36068dc7c1f301afa5b175eaac6f618e9db0773061ee527ef9935eb']
+
+java_options = '-Xmx2048m'
+
+osdependencies = [('p7zip-plugins', 'p7zip')]  # for extracting iso-files
+dependencies = [('MathWorksServiceHost', '2024.13.0.2')]
+
+# Use EB_MATLAB_LICENSE_SERVER and EB_MATLAB_LICENSE_SERVER_PORT environment variables or
+# uncomment and modify one of the following variables for installation with floating license server
+# license_file = 'XXXXXX'
+# license_server_port = 'XXXXX'
+
+# Add the correct path to matlab parallel server if applicable
+#modextrapaths = {
+#	'PATH': '/path/to/matlab_parallel_server/bin',
+#	'MATLABPATH': '/path/to/matlab_parallel_server/scripts',
+#}
+
+moduleclass = 'math'

--- a/o/OpenSim/OpenSim-4.3-foss-2024a.eb
+++ b/o/OpenSim/OpenSim-4.3-foss-2024a.eb
@@ -1,0 +1,53 @@
+easyblock = 'CMakeMake'
+
+name = 'OpenSim'
+version = '4.3'
+
+homepage = 'https://github.com/opensim-org/opensim-core'
+description = """OpenSim is software that lets users develop models of musculoskeletal structures and create dynamic simulations of movement"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/opensim-org/opensim-core/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['e4e7f6d9af5f8691374b0e5529efec6ed7bbc604b5ef10423320277e426d291f']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('SWIG', '4.1.1'),
+]
+
+dependencies = [
+    ('spdlog', '1.4.1'),
+    ('EZC3D', '1.4.3'),
+    ('MATLAB', '2024b-r5', '', SYSTEM),
+    ('Simbody', '20210317'),
+    ('CasADi-MATLAB', '20200618'),
+    ('ColPack', '20180108'),
+    ('Eigen', '3.4.0'),
+    ('ADOL-C', '2.7.2'),
+    ('Java', '1.8', '', SYSTEM),
+    ('docopt.cpp', '0.6.3')
+]
+
+# An old CMake module for MATLAB is included in the source which does not
+# handle recent MATLAB versions correctly. Remove it and realy on the CMake
+# module for MATLAB in the CMake installation instead.
+preconfigopts = 'rm ../opensim-core-4.3/cmake/FindMatlab.cmake && '
+
+configopts = ' -G"Unix Makefiles" -DOPENSIM_WITH_CASADI=on -DBUILD_JAVA_WRAPPING=on '
+configopts += '-DBUILD_PYTHON_WRAPPING=off -DOPENSIM_C3D_PARSER=ezc3d '
+configopts += '-DBUILD_TESTING=off -DOPENSIM_INSTALL_UNIX_FHS=off '
+configopts += '-DSWIG_DIR=${EBROOTSWIG} -DSIMBODY_HOME=${EBROOTSIMBODY} '
+configopts += '-DOPENSIM_WITH_TROPTER=off '
+
+sanity_check_paths = {
+    'files': ['bin/opensim-cmd'],
+    'dirs': ['sdk'],
+}
+
+modextrapaths = {
+    'CPATH': ['sdk/include', 'sdk/Simbody/include/simbody'],
+}
+
+moduleclass = 'tools'

--- a/o/OpenSimAD/OpenSimAD-20230213-foss-2024a.eb
+++ b/o/OpenSimAD/OpenSimAD-20230213-foss-2024a.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'OpenSimAD'
+version = '20230213'
+local_commit = '806a90504a893bee9cf57a6c5b2d8abe334db08b'
+
+homepage = 'https://github.com/antoinefalisse/opensim-core/'
+description = """OpenSim-based framework to solve trajectory optimization problems using direct collocation and algorithmic differentiation"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/antoinefalisse/opensim-core/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': 'opensim-core-AD-%(version)s.zip'}]
+checksums = ['eab803b83bba524ebcc7085c8c0123405ead7d1d0d5d7d12bb2ce55628bad914']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+    ('SimbodyAD', '20220901'),
+    ('BTKcore', '20180508'),
+    ('docopt.cpp', '0.6.3')
+]
+
+
+configopts = '-G"Unix Makefiles" -DSIMBODY_HOME=${EBROOTSIMBODYMINUSAD} '
+configopts += '-DWITH_BTK:BOOL=ON -DBTK_INSTALL_PREFIX=${EBROOTBTKCORE} '
+configopts += '-DBUILD_TESTING=off -DBUILD_API_EXAMPLES=off '
+configopts += '-DBUILD_EXTERNAL_FUNCTIONS=off -DWITH_RECORDER=on '
+configopts += '-DBUILD_JAVA_WRAPPING=off -DBUILD_PYTHON_WRAPPING=off '
+configopts += '-DBUILD_EXTERNAL_FUNCTIONS=off'
+
+sanity_check_paths = {
+    'files': ['lib/libSimTKsimbody.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'tools'

--- a/s/SWIG/SWIG-20180415-GCCcore-13.3.0-with-matlab.eb
+++ b/s/SWIG/SWIG-20180415-GCCcore-13.3.0-with-matlab.eb
@@ -1,0 +1,37 @@
+name = 'SWIG'
+version = '20180415'
+versionsuffix = '-with-matlab'
+local_commit = 'cd3f6c5fe9ed273fcc981dcae3e8b50d51529664'
+
+homepage = 'https://github.com/jaeandersson/swig/'
+description = """SWIG is a software development tool that connects programs written in C and C++ with
+ a variety of high-level programming languages. This specific version also supports MATLAB"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/jaeandersson/swig/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': '%(name)s-%(version)s.zip'}]
+checksums = ['b5ef6f988b97777c95e096ba20ff0b140b52b6330516a9070793b5af5644c63d']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Bison', '3.8.2'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('PCRE', '8.45'),
+]
+
+preconfigopts = 'sh autogen.sh && '
+configopts = '--without-alllang --with-boost=no --with-matlab'
+
+sanity_check_paths = {
+    'files': ['bin/swig'],
+    'dirs': ['share'],
+}
+
+sanity_check_commands = ['swig -help'] 
+
+moduleclass = 'devel'

--- a/s/SWIG/SWIG-4.1.1-GCCcore-13.3.0.eb
+++ b/s/SWIG/SWIG-4.1.1-GCCcore-13.3.0.eb
@@ -1,0 +1,27 @@
+name = 'SWIG'
+version = '4.1.1'
+
+homepage = 'http://www.swig.org/'
+description = """SWIG is a software development tool that connects programs written in C and C++ with
+ a variety of high-level programming languages."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('Bison', '3.8.2'),
+]
+
+dependencies = [
+    ('zlib', '1.3.1'),
+    ('PCRE2', '10.43'),
+]
+
+configopts = '--without-alllang --with-boost=no'
+
+moduleclass = 'devel'

--- a/s/Simbody/Simbody-20210317-foss-2024a.eb
+++ b/s/Simbody/Simbody-20210317-foss-2024a.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'Simbody'
+version = '20210317'
+local_commit = 'a8f49c84e98ccf3b7e6f05db55a29520e5f9c176'
+
+homepage = 'https://simtk.org/projects/simbody/'
+description = """Simbody is a high-performance, open-source toolkit for science- and engineering-quality simulation of articulated mechanisms, including biomechanical structures such as human and animal skeletons, mechanical systems like robots, vehicles, and machines, and anything else that can be described as a set of rigid bodies interconnected by joints, influenced by forces and motions, and restricted by constraints."""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/simbody/simbody/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': '%(namelower)s-%(version)s.zip'}]
+checksums = ['c93d09dbcbf83c8aaa9c0d8cdee39d5e95d4bdaa937f9cc911149927a802da57']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+]
+
+dependencies = []
+
+sanity_check_paths = {
+    'files': ['lib/libSimTKsimbody.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+modextrapaths = {
+    'CPATH': 'include/simbody'
+}
+
+# See https://github.com/simbody/simbody/issues/644 for the excluded test
+# https://github.com/simbody/simbody/issues/471#issuecomment-455824843
+test_cmd = 'ctest -E TestCustomConstraints -E TestGeo'
+
+moduleclass = 'tools'

--- a/s/SimbodyAD/SimbodyAD-20220901-foss-2024a.eb
+++ b/s/SimbodyAD/SimbodyAD-20220901-foss-2024a.eb
@@ -1,0 +1,31 @@
+easyblock = 'CMakeMake'
+
+name = 'SimbodyAD'
+version = '20220901'
+local_commit = '13fa3e10e7b9b5baa5f82448b9a4cc51766ab748'
+
+homepage = 'https://github.com/antoinefalisse/simbody/'
+description = """This is a simbody version that supports automatic differentiation"""
+
+toolchain = {'name': 'foss', 'version': '2024a'}
+
+source_urls = ['https://github.com/antoinefalisse/simbody/archive/']
+sources = [{'download_filename': '%s.zip' % local_commit, 'filename': 'simbody-AD-%(version)s.zip'}]
+checksums = ['ac3fba6ace51b9bb14841cd7aa4a7f1d828369f32d1fe4d637dcb8df8dffb8e0']
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+dependencies = [
+]
+
+configopts = '-DBUILD_TESTING=off -DBUILD_EXAMPLES=off -DBUILD_RECORDER_LIBRARIES:BOOL=ON -DBUILD_VISUALIZER:BOOL=OFF'
+
+sanity_check_paths = {
+    'files': ['lib/libSimTKsimbody.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'tools'

--- a/s/spdlog/spdlog-1.4.1-GCCcore-13.3.0.eb
+++ b/s/spdlog/spdlog-1.4.1-GCCcore-13.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'CMakeMake'
+
+name = 'spdlog'
+version = '1.4.1'
+
+homepage = 'https://github.com/gabime/spdlog'
+description = "Very fast, header-only/compiled, C++ logging library."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/gabime/%(name)s/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'spdlog-1.4.1_include-array.patch',
+    'spdlog-1.4.1_fix-missing-MINSIGSTKSZ.patch',
+]
+checksums = [
+    {'v1.4.1.tar.gz': '3291958eb54ed942d1bd3aef1b4f8ccf70566cbc04d34296ec61eb96ceb73cff'},
+    {'spdlog-1.4.1_include-array.patch': '805f48dc66dc67f429cd14b44738453fcd9c0179c484a62461eb80505aa07f77'},
+    {'spdlog-1.4.1_fix-missing-MINSIGSTKSZ.patch': '2b240b42128af91aaecd915f1182873bdacd2dbd2b99a5eaed7a641f7aa331a1'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+]
+
+configopts = "-DSPDLOG_BUILD_SHARED=ON "
+
+modextrapaths = {
+    'LD_LIBRARY_PATH': 'lib/spdlog',
+}
+
+sanity_check_paths = {
+    'files': ['include/%(name)s/%(name)s.h'],
+    'dirs': ['lib/spdlog/cmake', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/s/spdlog/spdlog-1.4.1_fix-missing-MINSIGSTKSZ.patch
+++ b/s/spdlog/spdlog-1.4.1_fix-missing-MINSIGSTKSZ.patch
@@ -1,0 +1,11 @@
+--- tests/catch.hpp.orig	2025-09-05 14:09:21.073093000 +0200
++++ tests/catch.hpp	2025-09-05 14:10:23.292451000 +0200
+@@ -9038,7 +9038,7 @@
+ 
+     // 32kb for the alternate stack seems to be sufficient. However, this value
+     // is experimentally determined, so that's not guaranteed.
+-    constexpr static std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
++    constexpr static std::size_t sigStackSize = 32768;
+ 
+     static SignalDefs signalDefs[] = {
+         { SIGINT,  "SIGINT - Terminal interrupt signal" },

--- a/s/spdlog/spdlog-1.4.1_include-array.patch
+++ b/s/spdlog/spdlog-1.4.1_include-array.patch
@@ -1,0 +1,10 @@
+--- include/spdlog/sinks/systemd_sink.h.orig	2025-04-29 09:50:19.656409000 +0200
++++ include/spdlog/sinks/systemd_sink.h	2025-04-29 09:49:37.434207000 +0200
+@@ -7,6 +7,7 @@
+ #include "spdlog/details/null_mutex.h"
+ #include "spdlog/details/synchronous_factory.h"
+ 
++#include <array>
+ #include <systemd/sd-journal.h>
+ 
+ namespace spdlog {


### PR DESCRIPTION
These easyconfigs provide the necessary modules to run [PredSim](https://github.com/KULeuvenNeuromechanics/PredSim) simulations (also look at this [PR](https://github.com/KULeuvenNeuromechanics/PredSim/pull/198)). The MATLAB easyconfigs requires customization to include license information. The required modules can be installed with:
```
eb --robot CasADi-3.7.0-gfbf-2024a.eb
eb --robot OpenSim-4.3-foss-2024a.eb
eb --robot OpenSimAD-20230213-foss-2024a.eb
```